### PR TITLE
DBTP 814: VPC module terraform tests

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -140,7 +140,7 @@ resource "aws_route_table_association" "private" {
 
 
 # Default ACL
-resource "aws_default_network_acl" "deafult-acl" {
+resource "aws_default_network_acl" "default-acl" {
   default_network_acl_id = aws_vpc.vpc.default_network_acl_id
   ingress {
     protocol   = -1

--- a/vpc/tests/vpc.tftest.hcl
+++ b/vpc/tests/vpc.tftest.hcl
@@ -1,0 +1,223 @@
+variables {
+  arg_name = "vpc-test-name"
+  arg_config = {
+    "cidr"         = "10.0",
+    "nat_gateways" = ["a"],
+    "az_map" = {
+      "private" = { "a" = "1", "b" = "2" },
+      "public"  = { "a" = "128", "b" = "129" }
+    }
+  }
+}
+
+run "aws_vpc_unit_test" {
+  command = plan
+
+  ### Test aws_vpc resource ###
+  assert {
+    condition     = aws_vpc.vpc.enable_dns_hostnames == true
+    error_message = "Invalid VPC settings"
+  }
+
+  assert {
+    condition     = aws_vpc.vpc.enable_dns_support == true
+    error_message = "Invalid VPC settings"
+  }
+
+  assert {
+    condition     = aws_vpc.vpc.tags.Name == "vpc-test-name"
+    error_message = "Invalid VPC tags"
+  }
+
+  assert {
+    condition     = aws_vpc.vpc.tags.managed-by == "Terraform"
+    error_message = "Invalid VPC tags"
+  }
+
+  ### Test aws_vpc_endpoint resource ###
+  assert {
+    condition     = aws_vpc_endpoint.rds-vpc-endpoint.service_name == "com.amazonaws.eu-west-2.secretsmanager"
+    error_message = "Invalid VPC endpoint service name"
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.rds-vpc-endpoint.private_dns_enabled == true
+    error_message = "Invalid VPC endpoint private dns status"
+  }
+}
+
+run "aws_security_group_unit_test" {
+  command = plan
+
+  ### Test aws_security_group resource ###
+  assert {
+    condition     = aws_security_group.vpc-core-sg.revoke_rules_on_delete == false
+    error_message = "Invalid security group settings"
+  }
+
+  ### Test aws_security_group_rule resource ###
+  assert {
+    condition     = aws_security_group_rule.rds-db-egress-db-to-lambda.protocol == "tcp"
+    error_message = "Invalid security group rule protocol"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-egress-db-to-lambda.type == "egress"
+    error_message = "Invalid security group rule type"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-egress-https.protocol == "tcp"
+    error_message = "Invalid security group rule protocol"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-egress-https.type == "egress"
+    error_message = "Invalid security group rule type"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-egress-sm-to-lambda.protocol == "tcp"
+    error_message = "Invalid security group rule protocol"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-egress-sm-to-lambda.type == "egress"
+    error_message = "Invalid security group rule type"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-ingress-fargate.protocol == "tcp"
+    error_message = "Invalid security group rule protocol"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-ingress-fargate.type == "ingress"
+    error_message = "Invalid security group rule type"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-ingress-lambda-to-db.protocol == "tcp"
+    error_message = "Invalid security group rule protocol"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-ingress-lambda-to-db.type == "ingress"
+    error_message = "Invalid security group rule type"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-ingress-lambda-to-sm.protocol == "tcp"
+    error_message = "Invalid security group rule protocol"
+  }
+
+  assert {
+    condition     = aws_security_group_rule.rds-db-ingress-lambda-to-sm.type == "ingress"
+    error_message = "Invalid security group rule type"
+  }
+}
+
+run "aws_subnet_unit_test" {
+  command = plan
+
+  ### Test aws_subnet private resource ###
+  assert {
+    condition     = aws_subnet.private["a"].availability_zone == "eu-west-2a"
+    error_message = "Invalid private subnet config"
+  }
+
+  assert {
+    condition     = aws_subnet.private["a"].cidr_block == "10.0.1.0/24"
+    error_message = "Invalid private subnet config"
+  }
+
+  assert {
+    condition     = aws_subnet.private["a"].map_public_ip_on_launch == false
+    error_message = "Invalid private subnet config"
+  }
+
+  assert {
+    condition     = aws_subnet.private["a"].tags.subnet_type == "private"
+    error_message = "Invalid private subnet config"
+  }
+
+  ### Test aws_subnet public resource ###
+  assert {
+    condition     = aws_subnet.public["a"].availability_zone == "eu-west-2a"
+    error_message = "Invalid public subnet config"
+  }
+
+  assert {
+    condition     = aws_subnet.public["a"].cidr_block == "10.0.128.0/24"
+    error_message = "Invalid public subnet config"
+  }
+
+  assert {
+    condition     = aws_subnet.public["a"].tags.subnet_type == "public"
+    error_message = "Invalid public subnet config"
+  }
+
+  ### Test aws_subnet.private-subnets resource ###
+  assert {
+    condition     = [for el in data.aws_subnets.private-subnets.filter : true if[for el2 in el.values : true if el2 == "vpc-test-name-private-*"][0] == true][0] == true
+    error_message = "Invalid aws private subnets filter"
+  }
+}
+
+run "aws_default_network_acl_unit_test" {
+  command = plan
+
+  ### Test aws_default_network_acl resource ###
+  assert {
+    condition     = [for el in aws_default_network_acl.default-acl.egress : true if el.action == "allow"][0] == true
+    error_message = "Invalid default network ACL"
+  }
+
+  assert {
+    condition     = [for el in aws_default_network_acl.default-acl.ingress : true if el.action == "allow"][0] == true
+    error_message = "Invalid default network ACL"
+  }
+}
+
+run "e2e_tests" {
+  command = apply
+
+  ### Test aws_vpc resource ###
+  assert {
+    condition     = aws_vpc.vpc.enable_dns_hostnames == true
+    error_message = "Invalid VPC settings"
+  }
+
+  assert {
+    condition     = aws_vpc.vpc.tags.Name == "vpc-test-name"
+    error_message = "Invalid VPC tags"
+  }
+
+  assert {
+    condition     = aws_vpc.vpc.tags.managed-by == "Terraform"
+    error_message = "Invalid VPC tags"
+  }
+
+  ### Test aws_security_group resource ###
+  assert {
+    condition     = startswith(aws_security_group.vpc-core-sg.arn, "arn:aws:ec2:eu-west-2:852676506468:security-group/sg-") == true
+    error_message = "Invalid security group settings"
+  }
+
+  ### Test aws_vpc_endpoint resource ###
+  assert {
+    condition     = aws_vpc_endpoint.rds-vpc-endpoint.vpc_endpoint_type == "Interface"
+    error_message = "Invalid VPC endpoint type"
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.rds-vpc-endpoint.state == "available"
+    error_message = "Invalid VPC endpoint state"
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.rds-vpc-endpoint.dns_options[0].dns_record_ip_type == "ipv4"
+    error_message = "Invalid VPC endpoint dns record ip type"
+  }
+}
+


### PR DESCRIPTION
Added terraform tests for the VPC module as part of work for [DBTP-814](https://uktrade.atlassian.net/browse/DBTP-814).

Tests are passing locally. They mainly comprise of unit tests running `command=plan` with a final e2e tests at the end that spins up a VPC and checks against some fields that are only available after a `command=apply`.
Run time of unit tests ~20 [s], with e2e test ~ 4 [mins].

```
time terraform test                             
tests/vpc.tftest.hcl... in progress
  run "aws_vpc_unit_test"... pass
  run "aws_security_group_unit_test"... pass
  run "aws_subnet_unit_test"... pass
  run "aws_default_network_acl_unit_test"... pass
  run "e2e_tests"... pass
tests/vpc.tftest.hcl... tearing down
╷
│ Warning: EC2 Default Network ACL (acl-09929deaee753893b) not deleted, removing from state
│ 
│ 
╵
tests/vpc.tftest.hcl... pass

Success! 5 passed, 0 failed.
terraform test  6.51s user 1.46s system 3% cpu 4:18.90 total
```

[DBTP-814]: https://uktrade.atlassian.net/browse/DBTP-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ