### PR TITLE
Fix Redis Security group

### DIFF
--- a/elasticache-redis/main.tf
+++ b/elasticache-redis/main.tf
@@ -64,9 +64,9 @@ resource "aws_security_group" "redis" {
   description = "Allow ingress from VPC for Redis"
 
   ingress {
-    from_port = 6379
-    to_port   = 6379
-    protocol  = "tcp"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
     cidr_blocks = [data.aws_vpc.vpc.cidr_block]
   }
   egress {


### PR DESCRIPTION
Rather than use the base SG to allow ECS to access to Redis, I have updated this to the VPC address.
Also including fix to naming of log groups and update some Terraform resource name to be camel-case.