### PR TITLE
feat: (DBTP-855) Add tests for Postgres

### DIFF
--- a/postgres/tests/postgres.tftest.hcl
+++ b/postgres/tests/postgres.tftest.hcl
@@ -75,7 +75,7 @@ run "aws_db_parameter_group_unit_test" {
   command = plan
 
   assert {
-    condition     = aws_db_parameter_group.default.name == "test-application-test-environment-test-name"
+    condition     = aws_db_parameter_group.default.name == "test-application-test-environment-test-name-postgres14"
     error_message = "Invalid name for aws_db_parameter_group.default"
   }
 


### PR DESCRIPTION
Terraform tests added for Postgres module as part of [DBTP-855](https://uktrade.atlassian.net/browse/DBTP-855).

Tests added for resources located in `cloudwatch.tf`, `lambda.tf`, `main.tf`, `rds.tf` and `secrets.tf`.
Tests are passing locally, however there is an intermittent issue with VPC availability:

```
Error: creating EC2 VPC: operation error EC2: CreateVpc, https response error StatusCode: 400, RequestID: c9e2ae89-fe85-48d6-a30f-adf9743b0f51, api error VpcLimitExceeded: The maximum number of VPCs has been reached.
```

[DBTP-855]: https://uktrade.atlassian.net/browse/DBTP-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ