### PR TITLE
fix: DBTP-884 - Rename Redis parameter

### DIFF
--- a/elasticache-redis/main.tf
+++ b/elasticache-redis/main.tf
@@ -72,7 +72,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_ssm_parameter" "endpoint" {
-  name        = "/copilot/${var.application}/${var.environment}/secrets/${upper(replace("${var.name}", "-", "_"))}"
+  name        = "/copilot/${var.application}/${var.environment}/secrets/${upper(replace("${var.name}_ENDPOINT", "-", "_"))}"
   description = "Redis endpoint"
   type        = "SecureString"
   value       = "rediss://${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379"

--- a/elasticache-redis/tests/elasticache-redis.tftest.hcl
+++ b/elasticache-redis/tests/elasticache-redis.tftest.hcl
@@ -181,7 +181,7 @@ run "aws_ssm_parameter_unit_test" {
 
   ### Test aws_ssm_parameter resource ###
   assert {
-    condition     = aws_ssm_parameter.endpoint.name == "/copilot/redis-test-application/redis-test-environment/secrets/REDIS_TEST_NAME"
+    condition     = aws_ssm_parameter.endpoint.name == "/copilot/redis-test-application/redis-test-environment/secrets/REDIS_TEST_NAME_ENDPOINT"
     error_message = "Invalid config for aws_ssm_parameter name"
   }
 


### PR DESCRIPTION
Update Redis parameter to match naming convention
`/copilot/<application>/<environment>/secrets/APPLICATION_REDIS_ENDPOINT`