### PR TITLE
fix: Parameterised account ID in unit test to allow tests to run in other accounts

### DIFF
--- a/elasticache-redis/tests/unit.tftest.hcl
+++ b/elasticache-redis/tests/unit.tftest.hcl
@@ -247,7 +247,7 @@ run "aws_cloudwatch_log_subscription_filter_unit_test" {
   }
 
   assert {
-    condition     = aws_cloudwatch_log_subscription_filter.redis-subscription-filter-engine.role_arn == "arn:aws:iam::852676506468:role/CWLtoSubscriptionFilterRole"
+    condition     = aws_cloudwatch_log_subscription_filter.redis-subscription-filter-engine.role_arn == "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/CWLtoSubscriptionFilterRole"
     error_message = "Invalid config for aws_cloudwatch_log_subscription_filter role_arn"
   }
 
@@ -268,7 +268,7 @@ run "aws_cloudwatch_log_subscription_filter_unit_test" {
   }
 
   assert {
-    condition     = aws_cloudwatch_log_subscription_filter.redis-subscription-filter-slow.role_arn == "arn:aws:iam::852676506468:role/CWLtoSubscriptionFilterRole"
+    condition     = aws_cloudwatch_log_subscription_filter.redis-subscription-filter-slow.role_arn == "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/CWLtoSubscriptionFilterRole"
     error_message = "Invalid config for aws_cloudwatch_log_subscription_filter role_arn"
   }
 }


### PR DESCRIPTION
Elasticache tests were failing due to hard coded account ID in ARN in unit tests.
Updated pick these up from the current account, so tests can be run from other accounts including platform-tools where the test CodeBuild projects live.