### PR TITLE
fix: Add domain provider alias to extensions unit test

### DIFF
--- a/extensions/tests/unit.tftest.hcl
+++ b/extensions/tests/unit.tftest.hcl
@@ -25,6 +25,10 @@ mock_provider "aws" {
   alias = "prod"
 }
 
+mock_provider "aws" {
+  alias = "domain"
+}
+
 run "aws_ssm_parameter_unit_test" {
   command = plan
 


### PR DESCRIPTION
This unit test for the extensions module had been failing due to missing provider information:
│ Error: missing provider provider["registry.terraform.io/hashicorp/aws"].domain

Added this alias to the test, which now passes.