### PR TITLE
test: DBTP-841 Allow yaml overrides to override the plan values for backing-services modules

### DIFF
--- a/extensions/tests/unit.tftest.hcl
+++ b/extensions/tests/unit.tftest.hcl
@@ -19,7 +19,7 @@ variables {
           "test-environment" : {
             "engine" : "2.11",
             "plan" : "small",
-            "volume_size": 512
+            "volume_size" : 512
           }
         }
       }


### PR DESCRIPTION
I believe the commented test below shows that we already support the feature request in this ticket https://uktrade.atlassian.net/browse/DBTP-841

Big thanks again to @adamwozencroft for help getting the baseline tests written.