### PR TITLE
fix: DBTP-839 Add tags for monitoring resources

### DIFF
--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -71,6 +71,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
       }
     ]
   })
+  # Tags are not supported: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard#argument-reference
 }
 
 resource "aws_resourcegroups_group" "application-insights-resources" {
@@ -91,10 +92,12 @@ resource "aws_resourcegroups_group" "application-insights-resources" {
       ]
     })
   }
+  tags = local.tags
 }
 
 resource "aws_applicationinsights_application" "application-insights" {
   resource_group_name = aws_resourcegroups_group.application-insights-resources.name
   auto_config_enabled = true
   ops_center_enabled  = var.config.enable_ops_center
+  tags                = local.tags
 }

--- a/monitoring/tests/unit.tftest.hcl
+++ b/monitoring/tests/unit.tftest.hcl
@@ -7,6 +7,13 @@ variables {
   config = {
     enable_ops_center = true
   }
+  expected_tags = {
+    application         = "test-application"
+    environment         = "test-environment"
+    managed-by          = "DBT Platform - Terraform"
+    copilot-application = "test-application"
+    copilot-environment = "test-environment"
+  }
 }
 
 # Compute dashboard
@@ -88,6 +95,11 @@ run "test_application_insights_resource_group_is_created" {
     )
     error_message = "Environment TagFilter is incorrect"
   }
+
+  assert {
+    condition     = jsonencode(aws_resourcegroups_group.application-insights-resources.tags) == jsonencode(var.expected_tags)
+    error_message = "Expected: ${jsonencode(var.expected_tags)}\nActual:   ${jsonencode(aws_resourcegroups_group.application-insights-resources.tags)}"
+  }
 }
 
 run "test_application_insights_application_is_created" {
@@ -106,6 +118,11 @@ run "test_application_insights_application_is_created" {
   assert {
     condition     = aws_applicationinsights_application.application-insights.ops_center_enabled == true
     error_message = "Should be: true"
+  }
+
+  assert {
+    condition     = jsonencode(aws_applicationinsights_application.application-insights.tags) == jsonencode(var.expected_tags)
+    error_message = "Expected: ${jsonencode(var.expected_tags)}\nActual:   ${jsonencode(aws_applicationinsights_application.application-insights.tags)}"
   }
 }
 


### PR DESCRIPTION
Highlighted by use of `tflint` whilst adding pre-commit hooks.