### PR TITLE
fix: DBTP-951 add prod check for additional address list

### DIFF
--- a/application-load-balancer/locals.tf
+++ b/application-load-balancer/locals.tf
@@ -24,9 +24,10 @@ locals {
   domain_prefix = coalesce(var.config.domain_prefix, "internal")
   domain_suffix = var.environment == "prod" ? coalesce(var.config.env_root, "prod.uktrade.digital") : coalesce(var.config.env_root, "uktrade.digital")
   domain_name   = var.environment == "prod" ? "${local.domain_prefix}.${var.application}.${local.domain_suffix}" : "${local.domain_prefix}.${var.environment}.${var.application}.${local.domain_suffix}"
+  additional_address_domain = try(var.environment == "prod" ? "${var.application}.${local.domain_suffix}" : "${var.environment}.${var.application}.${local.domain_suffix}")
 
   # Create map of all items in address list with its base domain. eg { x.y.base.com: base.com }
-  additional_address_fqdn = try({ for k in var.config.additional_address_list : "${k}.${var.environment}.${var.application}.${local.domain_suffix}" => "${var.application}.${local.domain_suffix}" }, {})
+  additional_address_fqdn = try({ for k in var.config.additional_address_list : "${k}.${local.additional_address_domain}" => "${var.application}.${local.domain_suffix}" }, {})
 
   # A List of domains that can be used in the Subject Alternative Name (SAN) part of the certificate.
   san_list = merge(local.additional_address_fqdn, var.config.cdn_domains_list)

--- a/application-load-balancer/locals.tf
+++ b/application-load-balancer/locals.tf
@@ -21,9 +21,9 @@ locals {
   }
 
   # The primary domain for every application follows these naming standard.  See README.md 
-  domain_prefix = coalesce(var.config.domain_prefix, "internal")
-  domain_suffix = var.environment == "prod" ? coalesce(var.config.env_root, "prod.uktrade.digital") : coalesce(var.config.env_root, "uktrade.digital")
-  domain_name   = var.environment == "prod" ? "${local.domain_prefix}.${var.application}.${local.domain_suffix}" : "${local.domain_prefix}.${var.environment}.${var.application}.${local.domain_suffix}"
+  domain_prefix             = coalesce(var.config.domain_prefix, "internal")
+  domain_suffix             = var.environment == "prod" ? coalesce(var.config.env_root, "prod.uktrade.digital") : coalesce(var.config.env_root, "uktrade.digital")
+  domain_name               = var.environment == "prod" ? "${local.domain_prefix}.${var.application}.${local.domain_suffix}" : "${local.domain_prefix}.${var.environment}.${var.application}.${local.domain_suffix}"
   additional_address_domain = try(var.environment == "prod" ? "${var.application}.${local.domain_suffix}" : "${var.environment}.${var.application}.${local.domain_suffix}")
 
   # Create map of all items in address list with its base domain. eg { x.y.base.com: base.com }


### PR DESCRIPTION
When configuring additional service, eg apis, additional web services in Prod, the autogenerated internal address is incorrectly adding a prod subdomain.  This checks if deploying to prod and adjusts the name.