### PR TITLE
fix: DBTP 951 fix prod prod cert bug

### DIFF
--- a/application-load-balancer/locals.tf
+++ b/application-load-balancer/locals.tf
@@ -24,9 +24,10 @@ locals {
   domain_prefix = coalesce(var.config.domain_prefix, "internal")
   domain_suffix = var.environment == "prod" ? coalesce(var.config.env_root, "prod.uktrade.digital") : coalesce(var.config.env_root, "uktrade.digital")
   domain_name   = var.environment == "prod" ? "${local.domain_prefix}.${var.application}.${local.domain_suffix}" : "${local.domain_prefix}.${var.environment}.${var.application}.${local.domain_suffix}"
+  additional_address_domain = try(var.environment == "prod" ? "${var.application}.${local.domain_suffix}" : "${var.environment}.${var.application}.${local.domain_suffix}")
 
   # Create map of all items in address list with its base domain. eg { x.y.base.com: base.com }
-  additional_address_fqdn = try({ for k in var.config.additional_address_list : "${k}.${var.environment}.${var.application}.${local.domain_suffix}" => "${var.application}.${local.domain_suffix}" }, {})
+  additional_address_fqdn = try({ for k in var.config.additional_address_list : "${k}.${local.additional_address_domain}" => "${var.application}.${local.domain_suffix}" }, {})
 
   # A List of domains that can be used in the Subject Alternative Name (SAN) part of the certificate.
   san_list = merge(local.additional_address_fqdn, var.config.cdn_domains_list)

--- a/application-load-balancer/locals.tf
+++ b/application-load-balancer/locals.tf
@@ -21,9 +21,9 @@ locals {
   }
 
   # The primary domain for every application follows these naming standard.  See README.md 
-  domain_prefix = coalesce(var.config.domain_prefix, "internal")
-  domain_suffix = var.environment == "prod" ? coalesce(var.config.env_root, "prod.uktrade.digital") : coalesce(var.config.env_root, "uktrade.digital")
-  domain_name   = var.environment == "prod" ? "${local.domain_prefix}.${var.application}.${local.domain_suffix}" : "${local.domain_prefix}.${var.environment}.${var.application}.${local.domain_suffix}"
+  domain_prefix             = coalesce(var.config.domain_prefix, "internal")
+  domain_suffix             = var.environment == "prod" ? coalesce(var.config.env_root, "prod.uktrade.digital") : coalesce(var.config.env_root, "uktrade.digital")
+  domain_name               = var.environment == "prod" ? "${local.domain_prefix}.${var.application}.${local.domain_suffix}" : "${local.domain_prefix}.${var.environment}.${var.application}.${local.domain_suffix}"
   additional_address_domain = try(var.environment == "prod" ? "${var.application}.${local.domain_suffix}" : "${var.environment}.${var.application}.${local.domain_suffix}")
 
   # Create map of all items in address list with its base domain. eg { x.y.base.com: base.com }

--- a/application-load-balancer/main.tf
+++ b/application-load-balancer/main.tf
@@ -140,7 +140,7 @@ resource "aws_route53_record" "additional-address" {
 
   count   = var.config.additional_address_list == null ? 0 : length(var.config.additional_address_list)
   zone_id = data.aws_route53_zone.domain-alb.zone_id
-  name    = "${var.config.additional_address_list[count.index]}.${var.environment}.${var.application}.${local.domain_suffix}"
+  name    = "${var.config.additional_address_list[count.index]}.${local.additional_address_domain}"
   type    = "CNAME"
   records = [aws_lb.this.dns_name]
   ttl     = 300


### PR DESCRIPTION
The duplicate Prod naming was fixed in the cert section of TF, but the duplicate was also present in the R53 naming of the additional addresses.  

This is to resolve that bug.