### PR TITLE
fix: dbtp-971 add rollback option for HA OS

### DIFF
--- a/opensearch/locals.tf
+++ b/opensearch/locals.tf
@@ -22,5 +22,6 @@ locals {
   zone_count             = local.zone_awareness_enabled ? local.instances : null
   subnets                = slice(tolist(data.aws_subnets.private-subnets.ids), 0, local.instances)
 
-  auto_tune_desired_state = startswith(var.config.instance, "t2") || startswith(var.config.instance, "t3") ? "DISABLED" : "ENABLED"
+  auto_tune_desired_state       = startswith(var.config.instance, "t2") || startswith(var.config.instance, "t3") ? "DISABLED" : "ENABLED"
+  auto_tune_rollback_on_disable = startswith(var.config.instance, "t2") || startswith(var.config.instance, "t3") ? "DEFAULT_ROLLBACK" : "NO_ROLLBACK"
 }

--- a/opensearch/main.tf
+++ b/opensearch/main.tf
@@ -139,7 +139,7 @@ resource "aws_opensearch_domain" "this" {
 
   auto_tune_options {
     desired_state       = local.auto_tune_desired_state
-    rollback_on_disable = "DEFAULT_ROLLBACK"
+    rollback_on_disable = local.auto_tune_rollback_on_disable
   }
 
   log_publishing_options {


### PR DESCRIPTION
When deploying Opensearch on any instance larger than small, you need to specify the NO_ROLLBACK option in auto tune.  This option has been added to fix this.