### PR TITLE
fix: add default volume size for rds local variable

### DIFF
--- a/postgres/locals.tf
+++ b/postgres/locals.tf
@@ -22,7 +22,7 @@ locals {
   skip_final_snapshot       = coalesce(var.config.skip_final_snapshot, false)
   final_snapshot_identifier = !local.skip_final_snapshot ? "${local.name}-${random_string.suffix.result}" : null
   snapshot_id               = var.config.snapshot_id
-  volume_size               = coalesce(var.config.volume_size, 20)
+  volume_size               = coalesce(var.config.volume_size, 100)
 
   instance_class = coalesce(var.config.instance, "db.t3.micro")
   storage_type   = coalesce(var.config.storage_type, "gp3")

--- a/postgres/tests/unit.tftest.hcl
+++ b/postgres/tests/unit.tftest.hcl
@@ -210,8 +210,8 @@ run "aws_db_instance_unit_test" {
   }
 
   assert {
-    condition     = aws_db_instance.default.allocated_storage == 20
-    error_message = "Should be: 20"
+    condition     = aws_db_instance.default.allocated_storage == 100
+    error_message = "Should be: 100"
   }
 
   assert {


### PR DESCRIPTION
- Update the RDS module default value for RDS instance volume size