### PR TITLE
feat: Make ``platform-helper copilot make-addons` run in the pipeline

### DIFF
--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -12,6 +12,9 @@ phases:
     commands:
       - echo "Terraform Plan Phase"
       - echo "Working on environment ${ENVIRONMENT}"
+      - echo "Generating manifests"
+      - copilot env init --name ${ENVIRONMENT} --profile ${COPILOT_PROFILE} --default-config
+      - ./build-tools/platform_helper.py copilot make-addons
       - cd terraform/${ENVIRONMENT}
       - terraform init
       - terraform plan -out=plan.tfplan

--- a/environment-pipelines/locals.tf
+++ b/environment-pipelines/locals.tf
@@ -19,7 +19,7 @@ locals {
         configuration : {
           ProjectName : "${var.application}-environment-pipeline-plan"
           PrimarySource : "build_output"
-          EnvironmentVariables : jsonencode([{ name : "ENVIRONMENT", value : env.name }])
+          EnvironmentVariables : jsonencode([{ name : "ENVIRONMENT", value : env.name }, { name : "COPILOT_PROFILE", value : env.accounts.deploy.name }])
         }
       },
       # The second element of the inner list for an env is the Approval stage if required, or the empty list otherwise.

--- a/environment-pipelines/stage_config.yml
+++ b/environment-pipelines/stage_config.yml
@@ -1,0 +1,28 @@
+---
+plan:
+  name: "Plan"
+  category: "Build"
+  owner: "AWS"
+  provider: "CodeBuild"
+  input_artifacts: ["build_output"]
+  output_artifacts: ["terraform_plan"]
+  namespace: "tf-plan"
+  version: "1"
+
+approve:
+  name: "Approval"
+  category: "Approval"
+  owner: "AWS"
+  provider: "Manual"
+  version: "1"
+  input_artifacts: []
+  output_artifacts: []
+
+apply:
+  name: "Apply"
+  category: "Build"
+  owner: "AWS"
+  provider: "CodeBuild"
+  input_artifacts: ["build_output", "terraform_plan"]
+  output_artifacts: []
+  version: "1"

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -401,6 +401,7 @@ run "test_iam" {
     condition     = aws_iam_role.environment_pipeline_codebuild.assume_role_policy == "{\"Sid\": \"AssumeCodebuildRole\"}"
     error_message = "Should be: {\"Sid\": \"AssumeCodebuildRole\"}"
   }
+  # Can't test managed_policy_arns of the environment_pipeline_codebuild role at plan time.
   assert {
     condition     = jsonencode(aws_iam_role.environment_pipeline_codebuild.tags) == jsonencode(var.expected_tags)
     error_message = "Should be: ${jsonencode(var.expected_tags)}"
@@ -588,6 +589,22 @@ run "test_iam" {
     error_message = "Should be: 'my-app-environment-pipeline-codebuild'"
   }
   # aws_iam_role_policy.opensearch_for_environment_codebuild.policy cannot be tested on a plan
+  assert {
+    condition     = aws_iam_policy.cloudformation.name == "cloudformation-access"
+    error_message = "Unexpected name"
+  }
+  assert {
+    condition     = aws_iam_policy.cloudformation.path == "/my-app/codebuild/"
+    error_message = "Unexpected path"
+  }
+  assert {
+    condition     = aws_iam_policy.cloudformation.description == "Allow my-app codebuild job to access cloudformation resources"
+    error_message = "Unexpected description"
+  }
+  assert {
+    condition     = aws_iam_policy.cloudformation.policy == "{\"Sid\": \"CloudFormation\"}"
+    error_message = "Unexpected policy"
+  }
 }
 
 run "test_artifact_store" {

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -871,3 +871,6 @@ run "test_stages" {
   }
 }
 
+
+
+

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -866,7 +866,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 }

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -133,6 +133,14 @@ override_data {
   }
 }
 
+override_data {
+  target = data.aws_iam_policy_document.cloudformation
+  values = {
+    json = "{\"Sid\": \"CloudFormation\"}"
+  }
+}
+
+
 variables {
   application = "my-app"
   repository  = "my-repository"
@@ -658,7 +666,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"sandbox\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 
@@ -712,7 +720,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"sandbox\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 
@@ -766,7 +774,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 
@@ -858,7 +866,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 }


### PR DESCRIPTION
This adds in permissions and pre-requisites for the `platform-helper copilot make-addons` to run in the pipeline. This required a `copilot env init` to ensure the copilot parameter store config is in place.