### PR TITLE
fix: Replay DBTP-944 remove "_ENDPOINT" from elasticache redis ssm parameter endpoint

### DIFF
--- a/.checkov.baseline
+++ b/.checkov.baseline
@@ -27,7 +27,8 @@
                 {
                     "resource": "module.extensions-staging.module.alb.aws_security_group.alb-security-group",
                     "check_ids": [
-                        "CKV_AWS_23"
+                        "CKV_AWS_23",
+                        "CKV2_AWS_5"
                     ]
                 }
             ]

--- a/application-load-balancer/main.tf
+++ b/application-load-balancer/main.tf
@@ -96,7 +96,7 @@ resource "aws_acm_certificate_validation" "cert_validate" {
 ## End of Application Load Balancer section.
 
 
-## Start of section that updates AWS R53 records in either the Dev or Prod AWS account, dependant on the provider aws.domain. 
+## Start of section that updates AWS R53 records in either the Dev or Prod AWS account, dependant on the provider aws.domain.
 
 # This makes sure the correct root domain is selected for each of the certificate fqdn.
 data "aws_route53_zone" "domain-root" {

--- a/elasticache-redis/tests/unit.tftest.hcl
+++ b/elasticache-redis/tests/unit.tftest.hcl
@@ -189,6 +189,16 @@ run "aws_ssm_parameter_unit_test" {
     condition     = aws_ssm_parameter.endpoint.type == "SecureString"
     error_message = "Invalid config for aws_ssm_parameter type"
   }
+
+  assert {
+    condition     = aws_ssm_parameter.endpoint_short.name == "/copilot/redis-test-application/redis-test-environment/secrets/REDIS_TEST_NAME"
+    error_message = "Invalid config for aws_ssm_parameter name"
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.endpoint_short.type == "SecureString"
+    error_message = "Invalid config for aws_ssm_parameter type"
+  }
 }
 
 run "aws_cloudwatch_log_group_unit_test" {


### PR DESCRIPTION
Because @WillGibson accidentally merged it with the breaking change indicator still there :-( 