### PR TITLE
fix: Fixed extensions module that was broken on the cdn declaration

### DIFF
--- a/extensions/main.tf
+++ b/extensions/main.tf
@@ -73,7 +73,6 @@ module "cdn" {
   }
   application = var.args.application
   environment = var.environment
-  vpc_name    = var.vpc_name
 
   config = each.value
 }


### PR DESCRIPTION
Tests were broken revealing a misconfiguration in the extensions module when it configures the cdn module.