### PR TITLE
feat: dbtp-928 option to disable cdn

### DIFF
--- a/cdn/tests/unit.tftest.hcl
+++ b/cdn/tests/unit.tftest.hcl
@@ -20,7 +20,7 @@ variables {
   vpc_name    = "vpc-name"
   config = {
     domain_prefix    = "dom-prefix",
-    cdn_domains_list = { "dev.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital"] }
+    cdn_domains_list = { "dev.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital"], "dev2.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital", "disable_cdn"] }
   }
 }
 
@@ -51,6 +51,25 @@ run "aws_cloudfront_distribution_unit_test" {
   assert {
     condition     = [for k in aws_cloudfront_distribution.standard["dev.my-application.uktrade.digital"].aliases : true if k == "dev.my-application.uktrade.digital"][0] == true
     error_message = "Should be: [ dev.my-application.uktrade.digital, ]"
+  }
+
+}
+
+run "aws_route53_record_unit_test_prod" {
+  command = plan
+
+  variables {
+    application = "app"
+    environment = "prod"
+    config = {
+      domain_prefix    = "dom-prefix",
+      cdn_domains_list = { "dev.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital"], "dev2.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital", "enable_record"] }
+    }
+  }
+
+  assert {
+    condition     = aws_route53_record.cdn-address["dev2.my-application.uktrade.digital"].name == "dev2.my-application.uktrade.digital"
+    error_message = "Should be: dev2.my-application.uktrade.digital"
   }
 
 }

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -12,7 +12,6 @@ variable "config" {
     env_root                = optional(string)
     cdn_domains_list        = optional(map(list(string)))
     additional_address_list = optional(list(string))
-    enable_cdn_record       = optional(bool)
     enable_logging          = optional(bool)
 
     # CDN default overrides


### PR DESCRIPTION
Adding a new feature in the CDN module to disable creation of the CDN endpoint.  This is required to stop the module from failing if the CDN already exists.  

Non breaking change.