### PR TITLE
fix: add  prometheus-policy to plans.yml

### DIFF
--- a/extensions/plans.yml
+++ b/extensions/plans.yml
@@ -222,3 +222,5 @@ monitoring: {}
 alb: {}
 
 cdn: {}
+
+prometheus-policy: {}


### PR DESCRIPTION
The prometheus-policy is a service addon, therefore not managed by terrraform.  We just need a `prometheus-policy` type adding to plans.yml to allow the terraform to run without errors.