### PR TITLE
fix: Don't generate environment Terraform manifest for demodjango toolspr

### DIFF
--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -17,7 +17,12 @@ phases:
       - echo "Terraform Plan Phase"
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting terraform plan phase for the ${ENVIRONMENT} environment."
       - echo "Working on environment ${ENVIRONMENT}"
-      - platform-helper environment generate-terraform --name "${ENVIRONMENT}"
+      - |
+        if [ "${APPLICATION}" == "demodjango" ] && [ "${ENVIRONMENT}" == "toolspr" ]; then
+          echo "Skipping platform-helper environment generate-terraform for demodjango toolspr environment until we can make it use terraform-platform-modules main branch"
+        else
+          platform-helper environment generate-terraform --name "${ENVIRONMENT}"
+        fi
       - cd terraform/environments/${ENVIRONMENT}
       - terraform init
       - terraform plan -out=plan.tfplan

--- a/environment-pipelines/locals.tf
+++ b/environment-pipelines/locals.tf
@@ -26,6 +26,7 @@ locals {
           ProjectName : "${var.application}-${var.pipeline_name}-environment-pipeline-plan"
           PrimarySource : "build_output"
           EnvironmentVariables : jsonencode([
+            { name : "APPLICATION", value : var.application },
             { name : "ENVIRONMENT", value : env.name },
             { name : "COPILOT_PROFILE", value : env.accounts.deploy.name },
             { name : "SLACK_CHANNEL_ID", value : var.slack_channel, type : "PARAMETER_STORE" },

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -741,7 +741,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"no\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"APPLICATION\",\"value\":\"my-app\"},{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"no\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
   assert {
@@ -853,7 +853,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"yes\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables == "[{\"name\":\"APPLICATION\",\"value\":\"my-app\"},{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"yes\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
   assert {


### PR DESCRIPTION
Because we need to use the `terraform-platform-modules` `main` branch for the regression tests.