### PR TITLE
fix: DBTP-1104 Ensure Terraform plan resources are available during apply stage.

### DIFF
--- a/environment-pipelines/buildspec-apply.yml
+++ b/environment-pipelines/buildspec-apply.yml
@@ -9,7 +9,6 @@ phases:
     commands:
       - export PATH="${CODEBUILD_SRC_DIR}/build-tools/bin:$PATH"
       - export PYTHONPATH="${CODEBUILD_SRC_DIR}/build-tools"
-      - eval export PLAN_TF_DIR=\$CODEBUILD_SRC_DIR_${ENVIRONMENT}_terraform_plan
   build:
     commands:
       - set -e
@@ -17,8 +16,7 @@ phases:
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting terraform apply phase for the ${ENVIRONMENT} environment."
       - echo -e "\nWorking on environment ${ENVIRONMENT}"
       - cd "terraform/environments/${ENVIRONMENT}"
-      - terraform init
-      - terraform apply "${PLAN_TF_DIR}/terraform/environments/${ENVIRONMENT}/plan.tfplan"
+      - terraform apply plan.tfplan
       - echo -e "\nGenerating manifests and deploying AWS Copilot environment resources"
       - cd "${CODEBUILD_SRC_DIR}"
       - platform-helper environment generate --name "${ENVIRONMENT}"

--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -42,5 +42,4 @@ phases:
         fi
 artifacts:
   files:
-    - terraform/environments/${ENVIRONMENT}/plan.tfplan
-    - copilot/environments/${ENVIRONMENT}/manifest.yml
+    - "**/*"

--- a/environment-pipelines/locals.tf
+++ b/environment-pipelines/locals.tf
@@ -55,11 +55,11 @@ locals {
         env : env.name,
         stage_name : "Apply-${env.name}",
         accounts : env.accounts,
-        input_artifacts : ["build_output", "${env.name}_terraform_plan"],
+        input_artifacts : ["${env.name}_terraform_plan"],
         output_artifacts : [],
         configuration : {
           ProjectName : "${var.application}-${var.pipeline_name}-environment-pipeline-apply"
-          PrimarySource : "build_output"
+          PrimarySource : "${env.name}_terraform_plan"
           EnvironmentVariables : jsonencode([
             { name : "ENVIRONMENT", value : env.name },
             { name : "SLACK_CHANNEL_ID", value : var.slack_channel, type : "PARAMETER_STORE" },

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -771,15 +771,11 @@ run "test_stages" {
     error_message = "Action provider incorrect"
   }
   assert {
-    condition     = length(aws_codepipeline.environment_pipeline.stage[3].action[0].input_artifacts) == 2
+    condition     = length(aws_codepipeline.environment_pipeline.stage[3].action[0].input_artifacts) == 1
     error_message = "Input artifacts incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].input_artifacts[0] == "build_output"
-    error_message = "Input artifacts incorrect"
-  }
-  assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].input_artifacts[1] == "dev_terraform_plan"
+    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].input_artifacts[0] == "dev_terraform_plan"
     error_message = "Input artifacts incorrect"
   }
   assert {
@@ -795,7 +791,7 @@ run "test_stages" {
     error_message = "Configuration ProjectName incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].configuration.PrimarySource == "build_output"
+    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].configuration.PrimarySource == "dev_terraform_plan"
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
@@ -925,15 +921,11 @@ run "test_stages" {
     error_message = "Action provider incorrect"
   }
   assert {
-    condition     = length(aws_codepipeline.environment_pipeline.stage[6].action[0].input_artifacts) == 2
+    condition     = length(aws_codepipeline.environment_pipeline.stage[6].action[0].input_artifacts) == 1
     error_message = "Input artifacts incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].input_artifacts[0] == "build_output"
-    error_message = "Input artifacts incorrect"
-  }
-  assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].input_artifacts[1] == "prod_terraform_plan"
+    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].input_artifacts[0] == "prod_terraform_plan"
     error_message = "Input artifacts incorrect"
   }
   assert {
@@ -949,7 +941,7 @@ run "test_stages" {
     error_message = "Configuration ProjectName incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.PrimarySource == "build_output"
+    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.PrimarySource == "prod_terraform_plan"
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {


### PR DESCRIPTION
Work done to pass entire build folder from plan stage to apply stage in order to:
- transfer the plan file properly
- transfer other built artifacts such as the lambda zip files.