### PR TITLE
fix: DBPT-1128 ResourceInitializationError Attempting to Connect to Redis via conduit

### DIFF
--- a/elasticache-redis/main.tf
+++ b/elasticache-redis/main.tf
@@ -80,6 +80,26 @@ resource "aws_kms_key" "ssm_redis_endpoint" {
   tags = local.tags
 }
 
+resource "aws_kms_key_policy" "ssm_redis_endpoint" {
+  key_id = aws_kms_key.ssm_redis_endpoint.arn
+  policy = jsonencode({
+    Id = "ECS Access to Decode CMK Secret"
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+}
+
 resource "aws_ssm_parameter" "endpoint_short" {
   name        = "/copilot/${var.application}/${var.environment}/secrets/${upper(replace(var.name, "-", "_"))}"
   description = "Redis endpoint (Deprecated in favour of endpoint_ssl which has the ssl_cert_reqs parameter baked in)"

--- a/opensearch/main.tf
+++ b/opensearch/main.tf
@@ -170,8 +170,56 @@ resource "aws_ssm_parameter" "opensearch_endpoint" {
   description = "opensearch_password"
   type        = "SecureString"
   value       = "https://${local.master_user}:${urlencode(random_password.password.result)}@${aws_opensearch_domain.this.endpoint}"
+  key_id      = aws_kms_key.ssm_opensearch_endpoint.arn
 
   tags = local.tags
+}
+resource "aws_kms_key" "ssm_opensearch_endpoint" {
+  # checkov:skip=CKV2_AWS_64:skipping pending discussion with rest of team on the policy
+  description             = "KMS key for ${var.name}-${var.application}-${var.environment}-opensearch-cluster SSM parameters"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+
+  tags = local.tags
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.name}-${var.application}-${var.environment}-ecsTask"
+  assume_role_policy = data.aws_iam_policy_document.assume_ecstask_role.json
+
+  inline_policy {
+    name = "AllowReadingofCMKSecrets"
+    policy = data.aws_iam_policy_document.access_ssm_with_kms.json
+  }
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "assume_ecstask_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "access_ssm_with_kms" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "ssm:GetParameters",
+      "logs:CreateLogStream"
+    ]
+    effect = "Allow"
+    resources = [
+      "*"
+    ]
+  }
 }
 
 data "aws_vpc" "vpc" {


### PR DESCRIPTION
Conduit was unable to connect to Redis since moving to using a CMK key - this change adds a key policy to the key used to store the Redis connection string - this restores Redis connectivity from conduit.