### PR TITLE
DBTP-1128 - Connection Error when trying to connect to Redis via Conduit

### DIFF
--- a/elasticache-redis/main.tf
+++ b/elasticache-redis/main.tf
@@ -80,6 +80,26 @@ resource "aws_kms_key" "ssm_redis_endpoint" {
   tags = local.tags
 }
 
+resource "aws_kms_key_policy" "ssm_redis_endpoint" {
+  key_id = aws_kms_key.ssm_redis_endpoint.arn
+  policy = jsonencode({
+    Id = "ECS Access to Decode CMK Secret"
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+}
+
 resource "aws_ssm_parameter" "endpoint_short" {
   name        = "/copilot/${var.application}/${var.environment}/secrets/${upper(replace(var.name, "-", "_"))}"
   description = "Redis endpoint (Deprecated in favour of endpoint_ssl which has the ssl_cert_reqs parameter baked in)"

--- a/elasticache-redis/main.tf
+++ b/elasticache-redis/main.tf
@@ -114,7 +114,11 @@ data "aws_iam_policy_document" "access_ssm_with_kms" {
     ]
     effect = "Allow"
     resources = [
-      "*"
+      aws_kms_key.ssm_redis_endpoint.arn,
+      aws_ssm_parameter.redis_url.arn,
+      aws_ssm_parameter.endpoint.arn,
+      aws_ssm_parameter.endpoint_short.arn,
+      "arn:aws:logs:*:*:*"
     ]
   }
 }

--- a/opensearch/main.tf
+++ b/opensearch/main.tf
@@ -217,7 +217,9 @@ data "aws_iam_policy_document" "access_ssm_with_kms" {
     ]
     effect = "Allow"
     resources = [
-      "*"
+      aws_kms_key.ssm_opensearch_endpoint.arn,
+      aws_ssm_parameter.opensearch_endpoint.arn,
+      "arn:aws:logs:*:*:*"
     ]
   }
 }

--- a/opensearch/main.tf
+++ b/opensearch/main.tf
@@ -170,8 +170,56 @@ resource "aws_ssm_parameter" "opensearch_endpoint" {
   description = "opensearch_password"
   type        = "SecureString"
   value       = "https://${local.master_user}:${urlencode(random_password.password.result)}@${aws_opensearch_domain.this.endpoint}"
+  key_id      = aws_kms_key.ssm_opensearch_endpoint.arn
 
   tags = local.tags
+}
+resource "aws_kms_key" "ssm_opensearch_endpoint" {
+  # checkov:skip=CKV2_AWS_64:skipping pending discussion with rest of team on the policy
+  description             = "KMS key for ${var.name}-${var.application}-${var.environment}-opensearch-cluster SSM parameters"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+
+  tags = local.tags
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.name}-${var.application}-${var.environment}-ecsTask"
+  assume_role_policy = data.aws_iam_policy_document.assume_ecstask_role.json
+
+  inline_policy {
+    name = "AllowReadingofCMKSecrets"
+    policy = data.aws_iam_policy_document.access_ssm_with_kms.json
+  }
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "assume_ecstask_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "access_ssm_with_kms" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "ssm:GetParameters",
+      "logs:CreateLogStream"
+    ]
+    effect = "Allow"
+    resources = [
+      "*"
+    ]
+  }
 }
 
 data "aws_vpc" "vpc" {


### PR DESCRIPTION
When trying to start a redis session via conduit a ResourceInitializationError message is displayed; this is related to Redis having a Customer Managed Key (CMK) to encrypt the SSM secrets rather than an AWS one. This change adds

- An IAM role to be used by ECS when running the conduit container
- An IAM policy to allow ECS tasks to use sts:AssumeRole attached to the above IAM role
- An IAM policy to allow ECS to access the SSM secret, decrypt the KMS key, and to write conduit logs attached to the above IAM role

Additionally the same modifications have been added the OpenSearch role; alongside enabling a CMK encrypted SSM secret in OpenSearch

This change in itself will not resolve DBTP-1128 but will provide a role that can be utilised by platform-helper. A separate PR will be submitted with the changes required for platform-helper.