### PR TITLE
feat: Removing all copilot commands from the terraform pipelines

### DIFF
--- a/environment-pipelines/buildspec-apply.yml
+++ b/environment-pipelines/buildspec-apply.yml
@@ -19,10 +19,6 @@ phases:
       - terraform apply plan.tfplan
       - echo -e "\nGenerating manifests and deploying AWS Copilot environment resources"
       - cd "${CODEBUILD_SRC_DIR}"
-      - platform-helper environment generate --name "${ENVIRONMENT}"
-      - copilot env init --name "${ENVIRONMENT}" --profile "${COPILOT_PROFILE}" --default-config
-      - platform-helper copilot make-addons
-      - copilot env deploy --name "${ENVIRONMENT}"
   post_build:
     commands:
       - |

--- a/environment-pipelines/buildspec.yml
+++ b/environment-pipelines/buildspec.yml
@@ -15,16 +15,10 @@ phases:
       - echo "Deploying ${APPLICATION} environments"
       - VERSION_OUTPUT=""
       - |
-        if [ ! -f .copilot-version ]; then
-          echo "Cannot find .copilot-version file"
-          exit 1
-        fi
-      - |
         if [ ! -f .platform-helper-version ]; then
           echo "Cannot find .platform-helper-version file"
           exit 1
         fi
-      - COPILOT_VERSION=`cat .copilot-version`
       - PLATFORM_HELPER_VERSION=`cat .platform-helper-version`
       - echo "Installing build tools"
       - yum -y install python-pip
@@ -44,12 +38,9 @@ phases:
       - unzip terraform_install.zip
       - chmod +x terraform
       - rm terraform_install.zip
-      - curl -s -qL -o copilot https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${COPILOT_VERSION}
-      - chmod +x copilot
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting install phase"
       - VERSION_OUTPUT+="\n$(terraform --version)"
       - VERSION_OUTPUT+="\n$(platform-helper --version)"
-      - VERSION_OUTPUT+="\n$(copilot --version)"
       - VERSION_OUTPUT+="\n$(python3 --version)"
       - VERSION_OUTPUT+="\n$(pip --version)"
       - echo -e "=============\nTool Versions\n-------------\n$VERSION_OUTPUT"


### PR DESCRIPTION
We do not need to run the copilot commands in the pipelines as they will have been run during the initial deployment of the environments. Only the terraform apply is relevant in the new environment pipelines.