### PR TITLE
feat: Support different versions of terraform-platform-modules in a pipeline.

### DIFF
--- a/environment-pipelines/buildspec-apply.yml
+++ b/environment-pipelines/buildspec-apply.yml
@@ -17,8 +17,6 @@ phases:
       - echo -e "\nWorking on environment ${ENVIRONMENT}"
       - cd "terraform/environments/${ENVIRONMENT}"
       - terraform apply plan.tfplan
-      - echo -e "\nGenerating manifests and deploying AWS Copilot environment resources"
-      - cd "${CODEBUILD_SRC_DIR}"
   post_build:
     commands:
       - |

--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -18,10 +18,15 @@ phases:
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting terraform plan phase for the ${ENVIRONMENT} environment."
       - echo "Working on environment ${ENVIRONMENT}"
       - |
+        ADDITIONAL_OPTIONS=
+        if [ ! -z "${TERRAFORM_PLATFORM_MODULES_VERSION}" ]
+        then 
+          $ADDITIONAL_OPTIONS+=" --terraform-platform-modules-version ${TERRAFORM_PLATFORM_MODULES_VERSION}"
+        fi
         if [ "${APPLICATION}" == "demodjango" ] && [ "${ENVIRONMENT}" == "toolspr" ]; then
           echo "Skipping platform-helper environment generate-terraform for demodjango toolspr environment until we can make it use terraform-platform-modules main branch"
         else
-          platform-helper environment generate-terraform --name "${ENVIRONMENT}"
+          platform-helper environment generate-terraform --name "${ENVIRONMENT}" "${ADDITIONAL_OPTIONS}"
         fi
       - cd terraform/environments/${ENVIRONMENT}
       - terraform init

--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -18,10 +18,9 @@ phases:
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting terraform plan phase for the ${ENVIRONMENT} environment."
       - echo "Working on environment ${ENVIRONMENT}"
       - |
-        ADDITIONAL_OPTIONS=
         if [ ! -z "${TERRAFORM_PLATFORM_MODULES_VERSION}" ]
         then 
-          $ADDITIONAL_OPTIONS+=" --terraform-platform-modules-version ${TERRAFORM_PLATFORM_MODULES_VERSION}"
+          $ADDITIONAL_OPTIONS=" --terraform-platform-modules-version ${TERRAFORM_PLATFORM_MODULES_VERSION}"
         fi
         if [ "${APPLICATION}" == "demodjango" ] && [ "${ENVIRONMENT}" == "toolspr" ]; then
           echo "Skipping platform-helper environment generate-terraform for demodjango toolspr environment until we can make it use terraform-platform-modules main branch"

--- a/environment-pipelines/locals.tf
+++ b/environment-pipelines/locals.tf
@@ -31,7 +31,8 @@ locals {
             { name : "COPILOT_PROFILE", value : env.accounts.deploy.name },
             { name : "SLACK_CHANNEL_ID", value : var.slack_channel, type : "PARAMETER_STORE" },
             { name : "SLACK_REF", value : "#{slack.SLACK_REF}" },
-            { name : "NEEDS_APPROVAL", value : lookup(env, "requires_approval", false) ? "yes" : "no" }
+            { name : "NEEDS_APPROVAL", value : lookup(env, "requires_approval", false) ? "yes" : "no" },
+            { name : "TERRAFORM_PLATFORM_MODULES_VERSION", value : lookup(var.versions, "terraform-platform-modules", "") }
           ])
         }
         namespace : "${env.name}-plan"

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -741,7 +741,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"APPLICATION\",\"value\":\"my-app\"},{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"no\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables == "[{\"name\":\"APPLICATION\",\"value\":\"my-app\"},{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"no\"},{\"name\":\"TERRAFORM_PLATFORM_MODULES_VERSION\",\"value\":\"\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
   assert {
@@ -849,7 +849,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables == "[{\"name\":\"APPLICATION\",\"value\":\"my-app\"},{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"yes\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables == "[{\"name\":\"APPLICATION\",\"value\":\"my-app\"},{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"COPILOT_PROFILE\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"NEEDS_APPROVAL\",\"value\":\"yes\"},{\"name\":\"TERRAFORM_PLATFORM_MODULES_VERSION\",\"value\":\"\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
   assert {
@@ -950,6 +950,23 @@ run "test_stages" {
   }
 }
 
+run "test_stages_have_configurable_terraform_platform_modules" {
+  command = plan
+  variables {
+    versions = {
+      terraform-platform-modules : "1.2.3"
+    }
+  }
 
+  # Stage: dev plan
+  assert {
+    condition     = strcontains(aws_codepipeline.environment_pipeline.stage[2].action[0].configuration.EnvironmentVariables, "{\"name\":\"TERRAFORM_PLATFORM_MODULES_VERSION\",\"value\":\"1.2.3\"}]")
+    error_message = "Configuration Env Vars incorrect"
+  }
 
-
+  # Stage: prod Plan
+  assert {
+    condition     = strcontains(aws_codepipeline.environment_pipeline.stage[4].action[0].configuration.EnvironmentVariables, "{\"name\":\"TERRAFORM_PLATFORM_MODULES_VERSION\",\"value\":\"1.2.3\"}]")
+    error_message = "Configuration Env Vars incorrect"
+  }
+}

--- a/environment-pipelines/variables.tf
+++ b/environment-pipelines/variables.tf
@@ -39,3 +39,8 @@ variable "trigger_on_push" {
   type    = bool
   default = true
 }
+
+variable "versions" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
This allow you to use a different version of this repo when generating the environment configuration in a pipeline. 

It now populates an env var TERRAFORM_PLATFORM_MODULES_VERSION for the plan stage from the "versions: terraform-platform-modules:" section of the platform-config.yml. This gets added to the platform-tools as an option that generates the appropriate manifest.