### PR TITLE
fix: DBTP-1128 Allow Pipeline Account to Create IAM Roles

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -737,8 +737,19 @@ data "aws_iam_policy_document" "iam" {
   statement {
     actions = [
       "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
       "iam:CreatePolicy",
+      "iam:DeletePolicy",
       "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:TagRole",
+      "iam:PutRolePolicy",
+      "iam:GetRole",
+      "iam:ListRolePolicies",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:DeleteRolePolicy",
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-${var.application}-*-conduitEcsTask",

--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -733,6 +733,26 @@ resource "aws_iam_policy" "cloudformation" {
   policy      = data.aws_iam_policy_document.cloudformation.json
 }
 
+data "aws_iam_policy_document" "iam" {
+  statement {
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreatePolicy",
+      "iam:CreateRole",
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-${var.application}-*-conduitEcsTask",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "iam" {
+  name        = "${var.application}-${var.pipeline_name}-pipeline-iam"
+  path        = "/${var.application}/codebuild/"
+  description = "Allow ${var.application} codebuild job to manage roles"
+  policy      = data.aws_iam_policy_document.iam.json
+}
+
 # Roles
 resource "aws_iam_role" "environment_pipeline_codepipeline" {
   name               = "${var.application}-${var.pipeline_name}-environment-pipeline-codepipeline"
@@ -744,6 +764,7 @@ resource "aws_iam_role" "environment_pipeline_codebuild" {
   name               = "${var.application}-${var.pipeline_name}-environment-pipeline-codebuild"
   assume_role_policy = data.aws_iam_policy_document.assume_codebuild_role.json
   managed_policy_arns = [
+    aws_iam_policy.iam.arn,
     aws_iam_policy.cloudformation.arn,
     aws_iam_policy.redis.arn,
     aws_iam_policy.postgres.arn,

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -147,6 +147,13 @@ override_data {
   }
 }
 
+override_data {
+  target = data.aws_iam_policy_document.iam
+  values = {
+    json = "{\"Sid\": \"IAM\"}"
+  }
+}
+
 variables {
   application   = "my-app"
   repository    = "my-repository"
@@ -663,6 +670,16 @@ run "test_iam" {
     error_message = "Should be: 'my-app-my-pipeline-environment-pipeline-codebuild'"
   }
   # aws_iam_role_policy.copilot_assume_role_for_environment_codebuild.policy cannot be tested on a plan
+
+  assert {
+    condition     = aws_iam_policy.iam.name == "my-app-my-pipeline-pipeline-iam"
+    error_message = "Should be: my-app-my-pipeline-pipeline-iam"
+  }
+
+  assert {
+    condition     = aws_iam_policy.iam.policy == "{\"Sid\": \"IAM\"}"
+    error_message = "Unexpected policy"
+  }
 }
 
 run "test_artifact_store" {

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -676,6 +676,7 @@ run "test_iam" {
     error_message = "Should be: my-app-my-pipeline-pipeline-iam"
   }
 
+  # IAM Policy not currently computed by mock due to https://github.com/hashicorp/terraform-provider-aws/issues/36700. Using override
   assert {
     condition     = aws_iam_policy.iam.policy == "{\"Sid\": \"IAM\"}"
     error_message = "Unexpected policy"


### PR DESCRIPTION
Grants permissions via IAM for the service account used to run pipelines to create/destroy IAM roles via Terraform