### PR TITLE
test: DBTP-1045 - Remove hardcoded account id from S3 e2e test

### DIFF
--- a/s3/e2e-tests/e2e.tftest.hcl
+++ b/s3/e2e-tests/e2e.tftest.hcl
@@ -85,7 +85,7 @@ run "aws_s3_object_e2e_test" {
   }
 
   assert {
-    condition     = strcontains(aws_s3_object.object["local_file"].kms_key_id, "${aws_kms_key.kms-key.id}")
+    condition     = aws_s3_object.object["local_file"].kms_key_id == "arn:aws:kms:eu-west-2:${data.aws_caller_identity.current.account_id}:key/${aws_kms_key.kms-key.id}"
     error_message = "Invalid kms key id"
   }
 

--- a/s3/e2e-tests/e2e.tftest.hcl
+++ b/s3/e2e-tests/e2e.tftest.hcl
@@ -29,8 +29,8 @@ run "aws_kms_key_e2e_test" {
   command = apply
 
   assert {
-    condition     = startswith(aws_kms_key.kms-key.arn, "arn:aws:kms:eu-west-2:852676506468") == true
-    error_message = "Should be: arn:aws:kms:eu-west-2:852676506468"
+    condition     = startswith(aws_kms_key.kms-key.arn, "arn:aws:kms:eu-west-2:${data.aws_caller_identity.current.account_id}") == true
+    error_message = "Should be: arn:aws:kms:eu-west-2:${data.aws_caller_identity.current.account_id}"
   }
 }
 
@@ -85,7 +85,7 @@ run "aws_s3_object_e2e_test" {
   }
 
   assert {
-    condition     = aws_s3_object.object["local_file"].kms_key_id == "arn:aws:kms:eu-west-2:852676506468:key/${aws_kms_key.kms-key.id}"
+    condition     = strcontains(aws_s3_object.object["local_file"].kms_key_id, "${aws_kms_key.kms-key.id}")
     error_message = "Invalid kms key id"
   }
 

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_s3_bucket" "this" {
   bucket = var.config.bucket_name
 


### PR DESCRIPTION
The account id is different when the E2E tests are running in CodeBuild.

Change the S3 e2e tests to use caller identity for the account id instead of a hard coded value.