### PR TITLE
fix: DBTP-1143 Prevent Trigger Being Deleted on TF Plan/Apply

### DIFF
--- a/environment-pipelines/codepipeline.tf
+++ b/environment-pipelines/codepipeline.tf
@@ -83,6 +83,12 @@ resource "aws_codepipeline" "environment_pipeline" {
   }
 
   tags = local.tags
+
+  lifecycle {
+    ignore_changes = [
+        trigger
+    ]
+  }
 }
 
 module "artifact_store" {

--- a/environment-pipelines/codepipeline.tf
+++ b/environment-pipelines/codepipeline.tf
@@ -86,7 +86,7 @@ resource "aws_codepipeline" "environment_pipeline" {
 
   lifecycle {
     ignore_changes = [
-        trigger
+      trigger
     ]
   }
 }


### PR DESCRIPTION
When trigger_on_push is set to true, it sets the DetectChanges in the environment pipeline to true, which causes a default trigger to be created for the pipeline, as this trigger is created outside of terraform it is not part of the state and terraform will attempt to delete it on each run. This issue is not experienced if trigger_on_push is set to false as the default trigger isn't created.

The only use of DetectChanges is in a single location - so instructing Terraform to ignore the trigger resolves the issue with no further impact. Attempting to recreate the trigger in terraform was unsuccessful and wouldn't match the default trigger.

This issue is discussed [here](https://github.com/hashicorp/terraform-provider-aws/issues/38409).