### PR TITLE
fix: DBTP-1149 - Cancel Outstanding Approval Requests before Performing a Terraform Plan

### DIFF
--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -15,7 +15,12 @@ phases:
     commands:
       - set -e
       - echo "Cancelling any pending approvals for ${APPLICATION}-${ENVIRONMENT}-environment-pipeline"
-      - aws codepipeline get-pipeline-state --name "${APPLICATION}-${ENVIRONMENT}-environment-pipeline" | jq  --arg stage "Approve-${ENVIRONMENT}" -r '.stageStates[] | select(.stageName == $stage and .latestExecution.status == "InProgress") | .latestExecution.pipelineExecutionId' | xargs -I {} aws codepipeline stop-pipeline-execution --pipeline-name "${APPLICATION}-${ENVIRONMENT}-environment-pipeline" --pipeline-execution-id {}  --abandon --reason "Abandoning previous pipeline execution pending approval to run terraform plan"
+      - PIPELINE_STATE=$(aws codepipeline get-pipeline-state --name "${APPLICATION}-${ENVIRONMENT}-environment-pipeline")
+      - PIPELINE_APPROVAL_EXECID=$(echo $PIPELINE_STATE | jq  --arg stage "Approve-${ENVIRONMENT}" -r '.stageStates[] | select(.stageName == $stage and .latestExecution.status == "InProgress") | .latestExecution.pipelineExecutionId')
+      - |
+        if [ -n "${PIPELINE_APPROVAL_EXECID}" ]; then
+          aws codepipeline stop-pipeline-execution --pipeline-name "${APPLICATION}-${ENVIRONMENT}-environment-pipeline" --pipeline-execution-id $PIPELINE_APPROVAL_EXECID --abandon --reason "Abandoning previous pipeline execution pending approval to run terraform plan" 
+        fi
       - echo "Terraform Plan Phase"
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting terraform plan phase for the ${ENVIRONMENT} environment."
       - echo "Working on environment ${ENVIRONMENT}"

--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -14,6 +14,8 @@ phases:
   build:
     commands:
       - set -e
+      - echo "Cancelling any pending approvals for ${APPLICATION}-${ENVIRONMENT}-environment-pipeline"
+      - aws codepipeline get-pipeline-state --name "${APPLICATION}-${ENVIRONMENT}-environment-pipeline" | jq  --arg stage "Approve-${ENVIRONMENT}" -r '.stageStates[] | select(.stageName == $stage and .latestExecution.status == "InProgress") | .latestExecution.pipelineExecutionId' | xargs -I {} aws codepipeline stop-pipeline-execution --pipeline-name "${APPLICATION}-${ENVIRONMENT}-environment-pipeline" --pipeline-execution-id {}  --abandon --reason "Abandoning previous pipeline execution pending approval to run terraform plan"
       - echo "Terraform Plan Phase"
       - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "Starting terraform plan phase for the ${ENVIRONMENT} environment."
       - echo "Working on environment ${ENVIRONMENT}"

--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -757,11 +757,30 @@ data "aws_iam_policy_document" "iam" {
   }
 }
 
+data "aws_iam_policy_document" "codepipeline" {
+  statement {
+    actions = [
+      "codepipeline:GetPipelineState",
+      "codepipeline:GetPipelineExecution",
+      "codepipeline:ListPipelineExecutions",
+      "codepipeline:StopPipelineExecution",
+    ]
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_policy" "iam" {
   name        = "${var.application}-${var.pipeline_name}-pipeline-iam"
   path        = "/${var.application}/codebuild/"
   description = "Allow ${var.application} codebuild job to manage roles"
   policy      = data.aws_iam_policy_document.iam.json
+}
+
+resource "aws_iam_policy" "codepipeline" {
+  name        = "${var.application}-${var.pipeline_name}-pipeline-codepipeline"
+  path        = "/${var.application}/codebuild/"
+  description = "Allow ${var.application} codebuild job to codepipelines"
+  policy      = data.aws_iam_policy_document.codepipeline.json
 }
 
 # Roles
@@ -777,6 +796,7 @@ resource "aws_iam_role" "environment_pipeline_codebuild" {
   managed_policy_arns = [
     aws_iam_policy.iam.arn,
     aws_iam_policy.cloudformation.arn,
+    aws_iam_policy.codepipeline.arn,
     aws_iam_policy.redis.arn,
     aws_iam_policy.postgres.arn,
     aws_iam_policy.opensearch.arn,

--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -765,7 +765,9 @@ data "aws_iam_policy_document" "codepipeline" {
       "codepipeline:ListPipelineExecutions",
       "codepipeline:StopPipelineExecution",
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:codepipeline:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.application}-${var.pipeline_name}-environment-pipeline"
+    ]
   }
 }
 

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -154,6 +154,13 @@ override_data {
   }
 }
 
+override_data {
+  target = data.aws_iam_policy_document.codepipeline
+  values = {
+    json = "{\"Sid\": \"codepipeline\"}"
+  }
+}
+
 variables {
   application   = "my-app"
   repository    = "my-repository"
@@ -679,6 +686,11 @@ run "test_iam" {
   # IAM Policy not currently computed by mock due to https://github.com/hashicorp/terraform-provider-aws/issues/36700. Using override
   assert {
     condition     = aws_iam_policy.iam.policy == "{\"Sid\": \"IAM\"}"
+    error_message = "Unexpected policy"
+  }
+
+  assert {
+    condition     = aws_iam_policy.codepipeline.policy == "{\"Sid\": \"codepipeline\"}"
     error_message = "Unexpected policy"
   }
 }


### PR DESCRIPTION
This change has two components

- Updated IAM permissions to allow the service account used to run pipelines to retrieve pipeline details, retrieve pipeline execution details; and to stop pipeline executions
- Add a command to the terraform plan pipeline stage to get any instances of InProgress Approval stages and to stop the execution of those pipeline instances before running the terraform plan.