### PR TITLE
fix: DBTP-1169 Added Validation for Domain Name Length

### DIFF
--- a/application-load-balancer/tests/unit.tftest.hcl
+++ b/application-load-balancer/tests/unit.tftest.hcl
@@ -252,3 +252,20 @@ run "aws_route53_record_unit_test" {
     error_message = "Should be: CNAME"
   }
 }
+
+run "domain_length_validation_tests" {
+  command = plan
+
+  variables {
+    application = "app"
+    environment = "env"
+    config = {
+      domain_prefix    = "dom-prefix",
+      cdn_domains_list = { "a-very-long-domain-name-used-to-test-length-validation.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital"] }
+    }
+  }
+
+  expect_failures = [
+    var.config.cdn_domains_list
+  ]
+}

--- a/application-load-balancer/variables.tf
+++ b/application-load-balancer/variables.tf
@@ -17,4 +17,11 @@ variable "config" {
     cdn_domains_list        = optional(map(list(string)))
     additional_address_list = optional(list(string))
   })
+
+  validation {
+    condition = alltrue([
+      for k, v in var.config.cdn_domains_list : ((length(k) <= 63) && (length(k) >= 3))
+    ])
+    error_message = "Items in cdn_domains_list should be between 3 and 63 characters long."
+  }
 }

--- a/cdn/tests/unit.tftest.hcl
+++ b/cdn/tests/unit.tftest.hcl
@@ -73,3 +73,20 @@ run "aws_route53_record_unit_test_prod" {
   }
 
 }
+
+run "domain_length_validation_tests" {
+  command = plan
+
+  variables {
+    application = "app"
+    environment = "env"
+    config = {
+      domain_prefix    = "dom-prefix",
+      cdn_domains_list = { "a-very-long-domain-name-used-to-test-length-validation.my-application.uktrade.digital" : ["internal", "my-application.uktrade.digital"] }
+    }
+  }
+
+  expect_failures = [
+    var.config.cdn_domains_list
+  ]
+}

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -32,4 +32,11 @@ variable "config" {
     cdn_logging_bucket                          = optional(string)
     cdn_logging_bucket_prefix                   = optional(string)
   })
+
+  validation {
+    condition = alltrue([
+      for k, v in var.config.cdn_domains_list : ((length(k) <= 63) && (length(k) >= 3))
+    ])
+    error_message = "Items in cdn_domains_list should be between 3 and 63 characters long."
+  }
 }


### PR DESCRIPTION
Added Validation to Variables.tf for both CDN and ALB modules to check the length of the domain name. This will throw the error 

`Error: Invalid value for variable
│
│   on ../../../../terraform-platform-modules/extensions/main.tf line 64, in module "alb":
│   64:   config = each.value
│     ├────────────────
│     │ var.config.cdn_domains_list is map of list of string with 1 element
│
│ Items in cdn_domains_list should be between 3 and 63 characters long.
│
│ This was checked by the validation rule at ../../../../terraform-platform-modules/application-load-balancer/variables.tf:21,3-13.`

If the domain name is > 63 characters or < 3 characters as per guidance [here](https://www.gov.uk/guidance/choose-your-govuk-domain-name?step-by-step-nav=5a9309a3-9a80-4faa-b24f-1797023e897f)