### PR TITLE
fix: Add tag to SSM param to allow global access

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -116,7 +116,9 @@ resource "aws_ssm_parameter" "combined_nat_gateway_eips" {
   name  = "/${var.arg_name}/EGRESS_IPS"
   type  = "String"
   value = join(",", local.nat_gateway_eips)
-  tags  = local.tags
+  tags = merge(local.tags, {
+    Copilot-application = "__all__"
+  })
 }
 
 

--- a/vpc/tests/unit.tftest.hcl
+++ b/vpc/tests/unit.tftest.hcl
@@ -56,6 +56,10 @@ run "aws_vpc_unit_test" {
     error_message = "Should be: String"
   }
 
+  assert {
+    condition     = aws_ssm_parameter.combined_nat_gateway_eips.tags.Copilot-application == "__all__"
+  }
+
   # aws_ssm_parameter.combined_nat_gateway_eips.value cannot be tested on a plan
 }
 


### PR DESCRIPTION
Copilot services by default can only access SSM params tagged  with the application and environment.  An associated change has been made in platform-tools to allow services to access any SSM parameter tagged with `Copilot-application = "__all__"`

This PR adds the tag to the SSM parameter containing egress IPs for a given VPC.