### PR TITLE
fix: cdn and application-load-balancer modules "null value cannot be used as the collection in a 'for' expression" error

### DIFF
--- a/application-load-balancer/tests/unit.tftest.hcl
+++ b/application-load-balancer/tests/unit.tftest.hcl
@@ -269,3 +269,18 @@ run "domain_length_validation_tests" {
     var.config.cdn_domains_list
   ]
 }
+
+run "domain_length_validation_tests_succeed_with_empty_config" {
+  command = plan
+
+  variables {
+    application = "app"
+    environment = "env"
+    config = {}
+  }
+
+  assert {
+    condition     = var.config.cdn_domains_list == null
+    error_message = "Should be: null"
+  }
+}

--- a/application-load-balancer/tests/unit.tftest.hcl
+++ b/application-load-balancer/tests/unit.tftest.hcl
@@ -276,7 +276,7 @@ run "domain_length_validation_tests_succeed_with_empty_config" {
   variables {
     application = "app"
     environment = "env"
-    config = {}
+    config      = {}
   }
 
   assert {

--- a/application-load-balancer/variables.tf
+++ b/application-load-balancer/variables.tf
@@ -19,7 +19,7 @@ variable "config" {
   })
 
   validation {
-    condition = alltrue([
+    condition = var.config.cdn_domains_list == null ? true : alltrue([
       for k, v in var.config.cdn_domains_list : ((length(k) <= 63) && (length(k) >= 3))
     ])
     error_message = "Items in cdn_domains_list should be between 3 and 63 characters long."

--- a/cdn/tests/unit.tftest.hcl
+++ b/cdn/tests/unit.tftest.hcl
@@ -97,7 +97,7 @@ run "domain_length_validation_tests_succeed_with_empty_config" {
   variables {
     application = "app"
     environment = "env"
-    config = {}
+    config      = {}
   }
 
   assert {

--- a/cdn/tests/unit.tftest.hcl
+++ b/cdn/tests/unit.tftest.hcl
@@ -90,3 +90,19 @@ run "domain_length_validation_tests" {
     var.config.cdn_domains_list
   ]
 }
+
+run "domain_length_validation_tests_succeed_with_empty_config" {
+  command = plan
+
+  variables {
+    application = "app"
+    environment = "env"
+    config = {}
+  }
+
+  assert {
+    condition     = var.config.cdn_domains_list == null
+    error_message = "Should be: null"
+  }
+}
+

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -34,7 +34,7 @@ variable "config" {
   })
 
   validation {
-    condition = alltrue([
+    condition = var.config.cdn_domains_list == null ? true : alltrue([
       for k, v in var.config.cdn_domains_list : ((length(k) <= 63) && (length(k) >= 3))
     ])
     error_message = "Items in cdn_domains_list should be between 3 and 63 characters long."


### PR DESCRIPTION
The validation on the optional cdn_domains_list variable used in cdn and application-load-balancer modules was causing an error when no domain lists were specified.
This change fixes the validation in the case of a null list.