### PR TITLE
fix: buildspec notify command ADDITIONAL_OPTIONS injection

### DIFF
--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -47,7 +47,7 @@ phases:
           MESSAGE=":alert: Terraform plan phase FAILED for the ${ENVIRONMENT} environment."
           ADDITIONAL_OPTIONS="--send-to-main-channel true"
         fi
-      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE}" $ADDITIONAL_OPTIONS
+      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE}" ${ADDITIONAL_OPTIONS}
 artifacts:
   files:
     - "**/*"

--- a/environment-pipelines/buildspec-plan.yml
+++ b/environment-pipelines/buildspec-plan.yml
@@ -47,7 +47,7 @@ phases:
           MESSAGE=":alert: Terraform plan phase FAILED for the ${ENVIRONMENT} environment."
           ADDITIONAL_OPTIONS="--send-to-main-channel true"
         fi
-      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE}" "${ADDITIONAL_OPTIONS}"
+      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE}" $ADDITIONAL_OPTIONS
 artifacts:
   files:
     - "**/*"

--- a/environment-pipelines/buildspec-trigger.yml
+++ b/environment-pipelines/buildspec-trigger.yml
@@ -46,7 +46,7 @@ phases:
           MESSAGE=":alert: @here FAILED to trigger ${TRIGGERED_PIPELINE_NAME}"
           ADDITIONAL_OPTIONS="--send-to-main-channel true"
         fi
-      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE} in the ${ACCOUNT_NAME} account." ${ADDITIONAL_OPTIONS}
+      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE} in the ${ACCOUNT_NAME} account." $ADDITIONAL_OPTIONS
 
 artifacts:
   files: []

--- a/environment-pipelines/buildspec-trigger.yml
+++ b/environment-pipelines/buildspec-trigger.yml
@@ -46,7 +46,7 @@ phases:
           MESSAGE=":alert: @here FAILED to trigger ${TRIGGERED_PIPELINE_NAME}"
           ADDITIONAL_OPTIONS="--send-to-main-channel true"
         fi
-      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE} in the ${ACCOUNT_NAME} account." $ADDITIONAL_OPTIONS
+      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE} in the ${ACCOUNT_NAME} account." ${ADDITIONAL_OPTIONS}
 
 artifacts:
   files: []

--- a/environment-pipelines/buildspec-trigger.yml
+++ b/environment-pipelines/buildspec-trigger.yml
@@ -46,7 +46,7 @@ phases:
           MESSAGE=":alert: @here FAILED to trigger ${TRIGGERED_PIPELINE_NAME}"
           ADDITIONAL_OPTIONS="--send-to-main-channel true"
         fi
-      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE} in the ${ACCOUNT_NAME} account." "${ADDITIONAL_OPTIONS}"
+      - platform-helper notify add-comment "${SLACK_CHANNEL_ID}" "${SLACK_TOKEN}" "${SLACK_REF}" "${MESSAGE} in the ${ACCOUNT_NAME} account." ${ADDITIONAL_OPTIONS}
 
 artifacts:
   files: []


### PR DESCRIPTION
The environment codebuild job failed because the notify command run during POST_BUILD in plan and trigger phases could not interpret the injected variable.
This change corrects the command by removing surplus double quotes.
