### PR TITLE
fix: DBTP-1301-provide-access-to-platform-s3-bucket

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -766,6 +766,7 @@ data "aws_iam_policy_document" "iam" {
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-${var.application}-*-conduitEcsTask",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-${var.application}-*-ExternalServiceAccessRole",
     ]
   }
 }


### PR DESCRIPTION
Addresses:
- Failing regression test environment pipeline
- Terraform plan failed as it did not have permission to delete the ${var.application}-*-ExternalServiceAccessRole" in the apply stage of the pipeline