### PR TITLE
fix: DBTP-1346 Add special characters & urlencode options for OpenSearch passwords

### DIFF
--- a/opensearch/locals.tf
+++ b/opensearch/locals.tf
@@ -16,6 +16,7 @@ locals {
   domain_name        = substr(replace("${var.environment}-${local.name}", "_", "-"), 0, 28)
   ssm_parameter_name = "/copilot/${var.application}/${var.environment}/secrets/${upper(replace("${var.name}_ENDPOINT", "-", "_"))}"
   master_user        = "opensearch_user"
+  urlencode_password = coalesce(var.config.urlencode_password, true)
 
   instances              = coalesce(var.config.instances, 1)
   zone_awareness_enabled = local.instances > 1

--- a/opensearch/main.tf
+++ b/opensearch/main.tf
@@ -89,16 +89,18 @@ resource "aws_security_group" "opensearch-security-group" {
 }
 
 resource "random_password" "password" {
-  length      = 32
-  upper       = true
-  special     = true
-  lower       = true
-  numeric     = true
-  min_upper   = 1
-  min_special = 1
-  min_lower   = 1
-  min_numeric = 1
+  length           = 32
+  upper            = true
+  special          = true
+  lower            = true
+  numeric          = true
+  min_upper        = 1
+  min_special      = 1
+  min_lower        = 1
+  min_numeric      = 1
+  override_special = coalesce(var.config.password_special_characters, "-_!.~$&'()*+,;=")
 }
+
 resource "aws_opensearch_domain" "this" {
   # checkov:skip=CKV_AWS_247: Enabling CMK Forces Cluster Recreation. To be implemented as a separate breaking change
   # checkov:skip=CKV2_AWS_59: This is a configurable option not picked up by Checkov as it's variablised
@@ -209,7 +211,7 @@ resource "aws_ssm_parameter" "opensearch_endpoint" {
   name        = local.ssm_parameter_name
   description = "opensearch_password"
   type        = "SecureString"
-  value       = "https://${local.master_user}:${urlencode(random_password.password.result)}@${aws_opensearch_domain.this.endpoint}"
+  value       = "https://${local.master_user}:${local.urlencode_password ? urlencode(random_password.password.result) : random_password.password.result}@${aws_opensearch_domain.this.endpoint}"
   key_id      = aws_kms_key.ssm_opensearch_endpoint.arn
 
   tags = local.tags

--- a/opensearch/tests/unit.tftest.hcl
+++ b/opensearch/tests/unit.tftest.hcl
@@ -30,11 +30,13 @@ run "test_create_opensearch" {
     vpc_name    = "terraform-tests-vpc"
 
     config = {
-      engine      = "2.5"
-      instance    = "t3.small.search"
-      instances   = 1
-      volume_size = 80
-      master      = false
+      engine                      = "2.5"
+      instance                    = "t3.small.search"
+      instances                   = 1
+      volume_size                 = 80
+      master                      = false
+      password_special_characters = "-_.,()"
+      urlencode_password          = false
     }
   }
 

--- a/opensearch/variables.tf
+++ b/opensearch/variables.tf
@@ -27,6 +27,8 @@ variable "config" {
     search_slow_log_retention_in_days = optional(number)
     es_app_log_retention_in_days      = optional(number)
     audit_log_retention_in_days       = optional(number)
+    password_special_characters       = optional(string)
+    urlencode_password                = optional(bool)
   })
 
   validation {


### PR DESCRIPTION
Digital Workspace OpenSearch integration cannot cope with urlencoded passwords, and also breaks when certain characters are present but not encoded (e.g. @)

This change allows teams to:
- disable urlencoding using the "urlencode_password" parameter
- define their own set of special characters using the "password_special_characters" parameter.

In addition I have defaulted the set of special characters to "-_!.~$&'()*+,;=" as these are considered safe if unencoded in the password.
