### PR TITLE
fix: DBTP-1366 - Force environment pipeline to trigger on correct branch

### DIFF
--- a/environment-pipelines/codepipeline.tf
+++ b/environment-pipelines/codepipeline.tf
@@ -24,6 +24,23 @@ resource "aws_codepipeline" "environment_pipeline" {
     }
   }
 
+  dynamic "trigger" {
+    for_each = var.trigger_on_push ? [1] : []
+    content {
+      provider_type = "CodeStarSourceConnection"
+      git_configuration {
+        source_action_name = "GitCheckout"
+        push {
+          branches {
+            includes = [
+              var.branch
+            ]
+          }
+        }
+      }
+    }
+  }
+
   stage {
     name = "Source"
 
@@ -91,12 +108,6 @@ resource "aws_codepipeline" "environment_pipeline" {
   }
 
   tags = local.tags
-
-  lifecycle {
-    ignore_changes = [
-      trigger
-    ]
-  }
 }
 
 module "artifact_store" {

--- a/environment-pipelines/codepipeline.tf
+++ b/environment-pipelines/codepipeline.tf
@@ -24,18 +24,15 @@ resource "aws_codepipeline" "environment_pipeline" {
     }
   }
 
-  dynamic "trigger" {
-    for_each = var.trigger_on_push ? [1] : []
-    content {
-      provider_type = "CodeStarSourceConnection"
-      git_configuration {
-        source_action_name = "GitCheckout"
-        push {
-          branches {
-            includes = [
-              var.branch
-            ]
-          }
+  trigger {
+    provider_type = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "GitCheckout"
+      push {
+        branches {
+          includes = [
+            var.trigger_on_push ? var.branch : "NO_TRIGGER"
+          ]
         }
       }
     }

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -406,7 +406,7 @@ run "test_pipeline_trigger_setup" {
 
   assert {
     condition     = aws_codepipeline.environment_pipeline.stage[0].action[0].configuration.DetectChanges == "false"
-    error_message = "Should be: true"
+    error_message = "Should be: false"
   }
 
   assert {

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -343,6 +343,11 @@ run "test_code_pipeline" {
     error_message = "Should be: main"
   }
 
+  assert {
+    condition     = aws_codepipeline.environment_pipeline.stage[0].action[0].configuration.DetectChanges == "true"
+    error_message = "Should be: true"
+  }
+
   # Build stage
   assert {
     condition     = aws_codepipeline.environment_pipeline.stage[1].name == "Install-Build-Tools"
@@ -389,6 +394,63 @@ run "test_code_pipeline" {
   assert {
     condition     = jsonencode(aws_codepipeline.environment_pipeline.tags) == jsonencode(var.expected_tags)
     error_message = "Should be: ${jsonencode(var.expected_tags)}"
+  }
+}
+
+run "test_pipeline_trigger_setup" {
+  command = plan
+
+  variables {
+    trigger_on_push = false
+  }
+
+  assert {
+    condition     = aws_codepipeline.environment_pipeline.stage[0].action[0].configuration.DetectChanges == "false"
+    error_message = "Should be: true"
+  }
+
+  assert {
+    condition     = contains(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes, "NO_TRIGGER")
+    error_message = "Should be: NO_TRIGGER"
+  }
+
+  assert {
+    condition     = length(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes) == 1
+    error_message = "Should be: true"
+  }
+}
+
+run "test_pipeline_trigger_branch" {
+  command = plan
+
+  variables {
+    branch = "my-branch"
+    trigger_on_push = true
+  }
+
+  assert {
+    condition     = aws_codepipeline.environment_pipeline.stage[0].action[0].configuration.BranchName == "my-branch"
+    error_message = "Should be: my-branch"
+  }
+
+  assert {
+    condition     = aws_codepipeline.environment_pipeline.trigger[0].provider_type == "CodeStarSourceConnection"
+    error_message = "Should be: CodeStarSourceConnection"
+  }
+
+  assert {
+    condition     = aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].source_action_name == "GitCheckout"
+    error_message = "Should be: GitCheckout"
+  }
+
+  assert {
+    condition     = contains(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes, "my-branch")
+    error_message = "Should be: true"
+  }
+
+  assert {
+    condition     = length(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes) == 1
+    error_message = "Should be: true"
   }
 }
 

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -416,7 +416,7 @@ run "test_pipeline_trigger_setup" {
 
   assert {
     condition     = length(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes) == 1
-    error_message = "Should be: true"
+    error_message = "The pipeline trigger should only have one push branch listed"
   }
 }
 
@@ -450,7 +450,7 @@ run "test_pipeline_trigger_branch" {
 
   assert {
     condition     = length(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes) == 1
-    error_message = "Should be: true"
+    error_message = "The pipeline trigger should only have one push branch listed"
   }
 }
 

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -424,7 +424,7 @@ run "test_pipeline_trigger_branch" {
   command = plan
 
   variables {
-    branch = "my-branch"
+    branch          = "my-branch"
     trigger_on_push = true
   }
 

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -445,7 +445,7 @@ run "test_pipeline_trigger_branch" {
 
   assert {
     condition     = contains(aws_codepipeline.environment_pipeline.trigger[0].git_configuration[0].push[0].branches[0].includes, "my-branch")
-    error_message = "Should be: true"
+    error_message = "Should be: my-branch"
   }
 
   assert {


### PR DESCRIPTION
Explicitly add a trigger block with the source branch to the environment pipeline.