### PR TITLE
fix: DBTP-1394 - Fix platform-helper environment generate command in environment pipeline apply stage

### DIFF
--- a/environment-pipelines/buildspec-apply.yml
+++ b/environment-pipelines/buildspec-apply.yml
@@ -19,23 +19,35 @@ phases:
       - terraform apply plan.tfplan
       - echo -e "\nGenerating manifests and deploying AWS Copilot environment resources"
       - cd "${CODEBUILD_SRC_DIR}"
+      - |
+        codebuild_assumed_role=$(aws sts assume-role --role-arn "${CURRENT_CODEBUILD_ROLE}" --role-session-name "environment-pipeline-platform-helper-generate-$(date +%s)")
+        AWS_ACCESS_KEY_ID=$(echo $codebuild_assumed_role | jq -r .Credentials.AccessKeyId)
+        AWS_SECRET_ACCESS_KEY=$(echo $codebuild_assumed_role | jq -r .Credentials.SecretAccessKey)
+        AWS_SESSION_TOKEN=$(echo $codebuild_assumed_role | jq -r .Credentials.SessionToken)
+        export PROFILE_NAME="${AWS_PROFILE_FOR_COPILOT}"
+        aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}" --profile "${PROFILE_NAME}"
+        aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}" --profile "${PROFILE_NAME}"
+        aws configure set aws_session_token "${AWS_SESSION_TOKEN}" --profile "${PROFILE_NAME}"
+        aws configure set region "eu-west-2" --profile "${PROFILE_NAME}"
+        aws configure set output "json" --profile "${PROFILE_NAME}"
+        export AWS_PROFILE="${PROFILE_NAME}"
       - platform-helper environment generate --name "${ENVIRONMENT}"
       - |
         if [[ "${AWS_PROFILE_FOR_COPILOT}" == *"prod"* ]]
         then
           echo -e "\nAssuming role to deploy AWS Copilot environment resources in prod account"
-          assumed_role=$(aws sts assume-role --role-arn "${TRIGGERING_ACCOUNT_CODEBUILD_ROLE}" --role-session-name "trigger-copilot-env-deploy-$(date +%s)")    
-          NON_PROD_AWS_ACCESS_KEY_ID=$(echo $assumed_role | jq -r .Credentials.AccessKeyId)
-          NON_PROD_AWS_SECRET_ACCESS_KEY=$(echo $assumed_role | jq -r .Credentials.SecretAccessKey)
-          NON_PROD_AWS_SESSION_TOKEN=$(echo $assumed_role | jq -r .Credentials.SessionToken)
+          triggering_account_assumed_role=$(aws sts assume-role --role-arn "${TRIGGERING_ACCOUNT_CODEBUILD_ROLE}" --role-session-name "environment-pipeline-copilot-env-deploy-$(date +%s)")    
+          AWS_ACCESS_KEY_ID=$(echo $triggering_account_assumed_role | jq -r .Credentials.AccessKeyId)
+          AWS_SECRET_ACCESS_KEY=$(echo $triggering_account_assumed_role | jq -r .Credentials.SecretAccessKey)
+          AWS_SESSION_TOKEN=$(echo $triggering_account_assumed_role | jq -r .Credentials.SessionToken)
           export PROFILE_NAME="${TRIGGERING_ACCOUNT_AWS_PROFILE}"
-          aws configure set aws_access_key_id "${NON_PROD_AWS_ACCESS_KEY_ID}" --profile "${PROFILE_NAME}"
-          aws configure set aws_secret_access_key "${NON_PROD_AWS_SECRET_ACCESS_KEY}" --profile "${PROFILE_NAME}"
-          aws configure set aws_session_token "${NON_PROD_AWS_SESSION_TOKEN}" --profile "${PROFILE_NAME}"
+          aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}" --profile "${PROFILE_NAME}"
+          aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}" --profile "${PROFILE_NAME}"
+          aws configure set aws_session_token "${AWS_SESSION_TOKEN}" --profile "${PROFILE_NAME}"
           aws configure set region "eu-west-2" --profile "${PROFILE_NAME}"
           aws configure set output "json" --profile "${PROFILE_NAME}"
           export AWS_PROFILE="${PROFILE_NAME}"
-        fi    
+        fi
       - copilot env init --name "${ENVIRONMENT}" --profile "${AWS_PROFILE_FOR_COPILOT}" --default-config
       - copilot env deploy --name "${ENVIRONMENT}"
   post_build:

--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -81,6 +81,26 @@ data "aws_iam_policy_document" "assume_codebuild_role" {
     actions = ["sts:AssumeRole"]
   }
 
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions = ["sts:AssumeRole"]
+
+    condition {
+      test     = "StringLike"
+      variable = "sts:RoleSessionName"
+
+      values = [
+        "environment-pipeline-platform-helper-generate-*"
+      ]
+    }
+  }
+
   dynamic "statement" {
     for_each = toset(local.triggers_another_pipeline ? [""] : [])
     content {
@@ -802,6 +822,13 @@ data "aws_iam_policy_document" "iam" {
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.application}-${statement.value.name}-EnvManagerRole"
       ]
     }
+  }
+
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.application}-${var.pipeline_name}-environment-pipeline-codebuild"]
   }
 }
 

--- a/environment-pipelines/locals.tf
+++ b/environment-pipelines/locals.tf
@@ -39,6 +39,7 @@ locals {
   triggering_pipeline_name           = local.triggered_by_another_pipeline ? one(local.list_of_triggering_pipelines).name : null
   triggering_pipeline_codebuild_role = local.triggered_by_another_pipeline ? "arn:aws:iam::${local.triggering_account_id}:role/${var.application}-${local.triggering_pipeline_name}-environment-pipeline-codebuild" : null
 
+  current_codebuild_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.application}-${var.pipeline_name}-environment-pipeline-codebuild"
 
   initial_stages = [for env in local.environment_config : [
     # The first element of the inner list for an env is the Plan stage.
@@ -94,6 +95,7 @@ locals {
           { name : "SLACK_CHANNEL_ID", value : var.slack_channel, type : "PARAMETER_STORE" },
           { name : "SLACK_REF", value : "#{slack.SLACK_REF}" },
           { name : "SLACK_THREAD_ID", value : "#{variables.SLACK_THREAD_ID}" },
+          { name : "CURRENT_CODEBUILD_ROLE", value : local.current_codebuild_role_arn },
           local.triggered_by_another_pipeline ? { name : "TRIGGERING_ACCOUNT_CODEBUILD_ROLE", value : local.triggering_pipeline_codebuild_role } : null,
           local.triggered_by_another_pipeline ? { name : "TRIGGERING_ACCOUNT_AWS_PROFILE", value : local.triggering_pipeline_account_name } : null,
         ])

--- a/environment-pipelines/tests/unit.tftest.hcl
+++ b/environment-pipelines/tests/unit.tftest.hcl
@@ -1094,12 +1094,12 @@ run "test_triggered_pipelines" {
   }
 
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},{\"name\":\"TRIGGERING_ACCOUNT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::000123456789:role/my-app-my-pipeline-environment-pipeline-codebuild\"},{\"name\":\"TRIGGERING_ACCOUNT_AWS_PROFILE\",\"value\":\"sandbox\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},{\"name\":\"CURRENT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/my-app-triggered-pipeline-environment-pipeline-codebuild\"},{\"name\":\"TRIGGERING_ACCOUNT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::000123456789:role/my-app-my-pipeline-environment-pipeline-codebuild\"},{\"name\":\"TRIGGERING_ACCOUNT_AWS_PROFILE\",\"value\":\"sandbox\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},{\"name\":\"TRIGGERING_ACCOUNT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::000123456789:role/my-app-my-pipeline-environment-pipeline-codebuild\"},{\"name\":\"TRIGGERING_ACCOUNT_AWS_PROFILE\",\"value\":\"sandbox\"}]"
+    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},{\"name\":\"CURRENT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/my-app-triggered-pipeline-environment-pipeline-codebuild\"},{\"name\":\"TRIGGERING_ACCOUNT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::000123456789:role/my-app-my-pipeline-environment-pipeline-codebuild\"},{\"name\":\"TRIGGERING_ACCOUNT_AWS_PROFILE\",\"value\":\"sandbox\"}]"
     error_message = "Configuration Env Vars incorrect"
   }
 }
@@ -1255,7 +1255,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},null,null]"
+    condition     = aws_codepipeline.environment_pipeline.stage[3].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"sandbox\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},{\"name\":\"CURRENT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/my-app-my-pipeline-environment-pipeline-codebuild\"},null,null]"
     error_message = "Configuration Env Vars incorrect"
   }
 
@@ -1405,7 +1405,7 @@ run "test_stages" {
     error_message = "Configuration PrimarySource incorrect"
   }
   assert {
-    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},null,null]"
+    condition     = aws_codepipeline.environment_pipeline.stage[6].action[0].configuration.EnvironmentVariables == "[{\"name\":\"ENVIRONMENT\",\"value\":\"prod\"},{\"name\":\"AWS_PROFILE_FOR_COPILOT\",\"value\":\"prod\"},{\"name\":\"SLACK_CHANNEL_ID\",\"type\":\"PARAMETER_STORE\",\"value\":\"/codebuild/slack_pipeline_notifications_channel\"},{\"name\":\"SLACK_REF\",\"value\":\"#{slack.SLACK_REF}\"},{\"name\":\"SLACK_THREAD_ID\",\"value\":\"#{variables.SLACK_THREAD_ID}\"},{\"name\":\"CURRENT_CODEBUILD_ROLE\",\"value\":\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/my-app-my-pipeline-environment-pipeline-codebuild\"},null,null]"
     error_message = "Configuration Env Vars incorrect"
   }
 }


### PR DESCRIPTION
The way the AWS profile was accessed in the `platform-helper environment generate` command changed in [this PR](https://github.com/uktrade/platform-tools/pull/568)

We now need a named AWS_PROFILE in the environment pipeline apply stage rather than using the inherited CodeBuild permissions.