### PR TITLE
fix: bucket name clashes

### DIFF
--- a/postgres/database-dump/locals.tf
+++ b/postgres/database-dump/locals.tf
@@ -7,7 +7,7 @@ locals {
     copilot-environment = var.environment
   }
 
-  task_name          = "${var.environment}-${var.database_name}-dump"
+  task_name          = "${var.application}-${var.environment}-${var.database_name}-dump"
   dump_kms_key_alias = "alias/${local.task_name}"
   dump_bucket_name   = local.task_name
 

--- a/postgres/database-load/locals.tf
+++ b/postgres/database-load/locals.tf
@@ -9,7 +9,7 @@ locals {
 
   task_name = "${var.environment}-${var.database_name}-load"
 
-  dump_task_name     = "${var.task.from}-${var.database_name}-dump"
+  dump_task_name     = "${var.application}-${var.task.from}-${var.database_name}-dump"
   dump_kms_key_alias = "alias/${local.dump_task_name}"
   dump_bucket_name   = local.dump_task_name
 

--- a/postgres/database-load/locals.tf
+++ b/postgres/database-load/locals.tf
@@ -7,7 +7,7 @@ locals {
     copilot-environment = var.environment
   }
 
-  task_name = "${var.environment}-${var.database_name}-load"
+  task_name = "${var.application}-${var.environment}-${var.database_name}-load"
 
   dump_task_name     = "${var.application}-${var.task.from}-${var.database_name}-dump"
   dump_kms_key_alias = "alias/${local.dump_task_name}"


### PR DESCRIPTION
Currently many databases are just called `database` in the platform config file, so for fft this would have been `prod-database-dump`, which isn't unique enough, this change makes it `fft-prod-database-dump`.