### PR TITLE
fix: Assume role policy for the S3 migration were too strict so relaxing them

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -875,7 +875,7 @@ data "aws_iam_policy_document" "iam" {
     actions = [
       "iam:UpdateAssumeRolePolicy"
     ]
-    resources = [for environment in local.environment_config : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.application}-${environment.name}-shared-S3MigrationRole"]
+    resources = [for environment in local.environment_config : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-S3MigrationRole"]
   }
 
   statement {

--- a/terraform_tests.sh
+++ b/terraform_tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+unit_test_files=$(find . -name "*tftest.hcl" | grep -v e2e-tests | sort)
+modules=""
+IFS=$'\n'
+for file in $unit_test_files
+do
+	# Lose leading ./ and select the part before the tests directory
+	module=$(echo "${file#./}" | awk -F "/tests/" '{print $1}')
+	# In case we separate the test files, only include each module once
+	if [[ "\"${modules}\"" != *"\"${module}\""* ]]; then
+	  message="Running tests for module ${module}"
+	  underline=$(echo "${message}" | sed "s/./=/g")
+		echo -en "\n\033[1;36m${message}\033[0m"
+		echo -e "\n\033[1;36m${underline}\033[0m"
+		pushd "${module}"
+    terraform init
+    terraform test
+    popd
+	fi
+done
+


### PR DESCRIPTION
The resources for the assume role were targetting a demodjango naming convention rather than allowing any s3 extension name. This fixes that (but still only targets S3 migration roles).