### PR TITLE
ci: Make Trufflehog just look at the local files for the pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
       - id: trufflehog
         name: TruffleHog
         description: Detect secrets in your data.
-        entry: bash -c 'trufflehog git file://. --no-verification --fail --exclude-paths=.trufflehogignore'
+        entry: bash -c 'trufflehog filesystem . --no-verification --fail --exclude-paths=.trufflehogignore'
         language: system
         stages: ["commit", "push"]


### PR DESCRIPTION
I had opened it up because it was missing a file I was trying to commit, but it meant it went off check the whole of the Git history.

---
## Checklist:

### Title:
- [X] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- ~[ ] Ticket reference included (unless it's a quick out of ticket thing)~
### Description:
- ~[ ] Link to ticket included (unless it's a quick out of ticket thing)~
- ~[ ] Includes tests (or an explanation for why it doesn't)~
- ~[ ] Includes any applicable changes to the documentation in this code base~
- ~[ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- ~[ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing~
