### PR TITLE
fix: Add missing environment pipeline permission

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -847,6 +847,13 @@ data "aws_iam_policy_document" "cloudformation" {
       "arn:aws:cloudformation:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stackset/${var.application}-infrastructure:*",
     ]
   }
+
+  statement {
+    actions = [
+      "cloudformation:ListExports"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "cloudformation" {


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1524

Add permission for pipeline to read cloudformation export

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
