### PR TITLE
fix: Missing environment pipeline permissions

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -607,6 +607,7 @@ data "aws_iam_policy_document" "postgres" {
         "iam:DeleteRolePolicy",
         "iam:PassRole",
         "iam:UpdateAssumeRolePolicy",
+        "iam:DetachRolePolicy"
       ]
       resources = [
         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.application}-${statement.value.name}-*",
@@ -625,7 +626,8 @@ data "aws_iam_policy_document" "postgres" {
         "lambda:GetFunctionCodeSigningConfig",
         "lambda:UpdateFunctionCode",
         "lambda:UpdateFunctionConfiguration",
-        "lambda:CreateFunction"
+        "lambda:CreateFunction",
+        "lambda:DeleteFunction"
       ]
       resources = [
         "arn:aws:lambda:${local.account_region}:function:${var.application}-${statement.value.name}-*"
@@ -834,7 +836,8 @@ data "aws_iam_policy_document" "origin_secret_rotate_access" {
       "lambda:DeleteFunction",
       "lambda:TagResource",
       "lambda:PutFunctionConcurrency",
-      "lambda:AddPermission"
+      "lambda:AddPermission",
+      "lambda:DeleteFunction"
     ]
     resources = [
       for env in local.environment_config : "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.application}-${env.name}-origin-secret-rotate"


### PR DESCRIPTION
Add permission to delete lambda functions.

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
