### PR TITLE
feat: DBTP-1687 Reduce length of artifact and KMS key names

### DIFF
--- a/codebase-pipelines/artifactstore.tf
+++ b/codebase-pipelines/artifactstore.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "artifact_store" {
   # checkov:skip=CKV2_AWS_62: It's just a pipeline artifacts bucket, event notifications are not needed.
   # checkov:skip=CKV_AWS_21: It's just a pipeline artifacts bucket, versioning is not needed.
   # checkov:skip=CKV_AWS_18: It's just a pipeline artifacts bucket, access logging is not needed.
-  bucket = "${var.application}-${var.codebase}-codebase-pipeline-artifact-store"
+  bucket = "${var.application}-${var.codebase}-cb-arts"
 
   tags = local.tags
 }
@@ -96,7 +96,7 @@ resource "aws_kms_key" "artifact_store_kms_key" {
 
 resource "aws_kms_alias" "artifact_store_kms_alias" {
   depends_on    = [aws_kms_key.artifact_store_kms_key]
-  name          = "alias/${var.application}-${var.codebase}-codebase-pipeline-artifact-store-key"
+  name          = "alias/${var.application}-${var.codebase}-cb-arts-key"
   target_key_id = aws_kms_key.artifact_store_kms_key.id
 }
 

--- a/codebase-pipelines/tests/unit.tftest.hcl
+++ b/codebase-pipelines/tests/unit.tftest.hcl
@@ -147,12 +147,12 @@ run "test_artifact_store" {
   command = plan
 
   assert {
-    condition     = aws_s3_bucket.artifact_store.bucket == "my-app-my-codebase-codebase-pipeline-artifact-store"
-    error_message = "Should be: my-app-my-codebase-codebase-pipeline-artifact-store"
+    condition     = aws_s3_bucket.artifact_store.bucket == "my-app-my-codebase-cb-arts"
+    error_message = "Should be: my-app-my-codebase-cb-arts"
   }
   assert {
-    condition     = aws_kms_alias.artifact_store_kms_alias.name == "alias/my-app-my-codebase-codebase-pipeline-artifact-store-key"
-    error_message = "Should be: alias/my-app-my-codebase-codebase-pipeline-artifact-store-key"
+    condition     = aws_kms_alias.artifact_store_kms_alias.name == "alias/my-app-my-codebase-cb-arts-key"
+    error_message = "Should be: alias/my-app-my-codebase-cb-arts-key"
   }
   assert {
     condition     = [for el in data.aws_iam_policy_document.artifact_store_bucket_policy.statement[0].condition : el.variable][0] == "aws:SecureTransport"
@@ -809,8 +809,8 @@ run "test_codebuild_deploy" {
     error_message = "Should be: 'S3'"
   }
   assert {
-    condition     = one(aws_codebuild_project.codebase_deploy.cache).location == "my-app-my-codebase-codebase-pipeline-artifact-store"
-    error_message = "Should be: 'my-app-my-codebase-codebase-pipeline-artifact-store'"
+    condition     = one(aws_codebuild_project.codebase_deploy.cache).location == "my-app-my-codebase-cb-arts"
+    error_message = "Should be: 'my-app-my-codebase-cb-arts'"
   }
   assert {
     condition     = one(aws_codebuild_project.codebase_deploy.environment).compute_type == "BUILD_GENERAL1_SMALL"
@@ -900,8 +900,8 @@ run "test_main_pipeline" {
     error_message = "Should be: 'Tagged image in ECR to deploy'"
   }
   assert {
-    condition     = tolist(aws_codepipeline.codebase_pipeline[0].artifact_store)[0].location == "my-app-my-codebase-codebase-pipeline-artifact-store"
-    error_message = "Should be: 'my-app-my-codebase-codebase-pipeline-artifact-store'"
+    condition     = tolist(aws_codepipeline.codebase_pipeline[0].artifact_store)[0].location == "my-app-my-codebase-cb-arts"
+    error_message = "Should be: 'my-app-my-codebase-cb-arts'"
   }
   assert {
     condition     = tolist(aws_codepipeline.codebase_pipeline[0].artifact_store)[0].type == "S3"
@@ -1192,8 +1192,8 @@ run "test_manual_release_pipeline" {
     error_message = "Should be: 'Name of the environment to deploy to'"
   }
   assert {
-    condition     = tolist(aws_codepipeline.manual_release_pipeline.artifact_store)[0].location == "my-app-my-codebase-codebase-pipeline-artifact-store"
-    error_message = "Should be: 'my-app-my-codebase-codebase-pipeline-artifact-store'"
+    condition     = tolist(aws_codepipeline.manual_release_pipeline.artifact_store)[0].location == "my-app-my-codebase-cb-arts"
+    error_message = "Should be: 'my-app-my-codebase-cb-arts'"
   }
   assert {
     condition     = tolist(aws_codepipeline.manual_release_pipeline.artifact_store)[0].type == "S3"

--- a/extensions/iam.tf
+++ b/extensions/iam.tf
@@ -63,8 +63,8 @@ data "aws_iam_policy_document" "artifact_store_access" {
       "s3:PutObject",
     ]
     resources = [
-      "arn:aws:s3:::${var.args.application}-*-codebase-pipeline-artifact-store/*",
-      "arn:aws:s3:::${var.args.application}-*-codebase-pipeline-artifact-store"
+      "arn:aws:s3:::${var.args.application}-*-cb-arts/*",
+      "arn:aws:s3:::${var.args.application}-*-cb-arts"
     ]
   }
 

--- a/extensions/tests/unit.tftest.hcl
+++ b/extensions/tests/unit.tftest.hcl
@@ -441,7 +441,7 @@ run "codebase_deploy_iam_test" {
     error_message = "Unexpected actions"
   }
   assert {
-    condition     = data.aws_iam_policy_document.artifact_store_access.statement[0].resources == toset(["arn:aws:s3:::test-application-*-codebase-pipeline-artifact-store", "arn:aws:s3:::test-application-*-codebase-pipeline-artifact-store/*"])
+    condition     = data.aws_iam_policy_document.artifact_store_access.statement[0].resources == toset(["arn:aws:s3:::test-application-*-cb-arts", "arn:aws:s3:::test-application-*-cb-arts/*"])
     error_message = "Unexpected resources"
   }
   assert {


### PR DESCRIPTION
Addresses [DBTP-1687](https://uktrade.atlassian.net/browse/DBTP-1687)

Reduce the length of names due to character limits
updated tests to reference newly named resources

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing


[DBTP-1687]: https://uktrade.atlassian.net/browse/DBTP-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ