### PR TITLE
feat: Add table to CloudWatch dashboard to show deployed images

### DIFF
--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -9,6 +9,34 @@ resource "aws_cloudwatch_dashboard" "compute" {
         x : 0,
         type : "log",
         properties : {
+          query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields fromMillis(Timestamp) as Time, ClusterName as Cluster, TaskDefinitionFamily as Service, ContainerName as Container, Image\n| filter @message like 'application:'\n| sort Cluster, Service, Container\n| dedup Service, Container",
+          region : "eu-west-2",
+          stacked : false,
+          title : "Deployed Application Images",
+          view : "table"
+        }
+      },
+      {
+        height : 7,
+        width : 24,
+        y : 7,
+        x : 0,
+        type : "log",
+        properties : {
+          query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields fromMillis(Timestamp) as Time, ClusterName as Cluster, TaskDefinitionFamily as Service, ContainerName as Container, Image\n| filter @message like '\"Image\":'\n| filter @message not like 'application:'\n| sort Cluster, Service, Container\n| dedup Service, Container",
+          region : "eu-west-2",
+          stacked : false,
+          title : "Deployed Sidecar Images",
+          view : "table"
+        }
+      },
+      {
+        height : 7,
+        width : 24,
+        y : 14,
+        x : 0,
+        type : "log",
+        properties : {
           query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields @message\n| filter Type=\"Task\"\n| filter @logStream like /FargateTelemetry/\n| stats latest(TaskDefinitionFamily) as TaskDefFamily, \n        latest(TaskDefinitionRevision) as Rev, \n        max(CpuReserved) as TaskCpuReserved, \n        avg(CpuUtilized) as AvgCpuUtilized, \n        concat(ceil(avg(CpuUtilized) * 100 / TaskCpuReserved),\" %\") as AvgCpuUtilizedPerc, \n        max(CpuUtilized) as PeakCpuUtilized, \n        concat(ceil(max(CpuUtilized) * 100 / TaskCpuReserved),\" %\") as PeakCpuUtilizedPerc, \n        max(MemoryReserved) as TaskMemReserved, \n        ceil(avg(MemoryUtilized)) as AvgMemUtilized, \n        concat(ceil(avg(MemoryUtilized) * 100 / TaskMemReserved),\" %\") as AvgMemUtilizedPerc, \n        max(MemoryUtilized) as PeakMemUtilized, \n        concat(ceil(max(MemoryUtilized) * 100 / TaskMemReserved),\" %\") as PeakMemUtilizedPerc \n        by TaskId\n| sort TaskDefFamily asc\n",
           region : "eu-west-2",
           stacked : false,
@@ -19,7 +47,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
       {
         height : 6,
         width : 15,
-        y : 7,
+        y : 21,
         x : 0,
         type : "log",
         properties : {
@@ -32,7 +60,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
       {
         height : 6,
         width : 15,
-        y : 13,
+        y : 27,
         x : 0,
         type : "log",
         properties : {
@@ -45,7 +73,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
       {
         height : 6,
         width : 9,
-        y : 7,
+        y : 21,
         x : 15,
         type : "log",
         properties : {
@@ -59,7 +87,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
       {
         height : 6,
         width : 9,
-        y : 13,
+        y : 27,
         x : 15,
         type : "log",
         properties : {

--- a/monitoring/tests/unit.tftest.hcl
+++ b/monitoring/tests/unit.tftest.hcl
@@ -34,7 +34,7 @@ run "test_compute_dashboard_is_created" {
 
   assert {
     condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[1].properties.title == "Deployed Sidecar Images"
-    error_message = "Deployed Sidecar Images"
+    error_message = "Deployed Sidecar Images widget is not created"
   }
 
   assert {

--- a/monitoring/tests/unit.tftest.hcl
+++ b/monitoring/tests/unit.tftest.hcl
@@ -28,27 +28,37 @@ run "test_compute_dashboard_is_created" {
   # Test widgets are created
   # Not checking the whole queries as we would just have to replicate the code from the manifest, which would not add much value, so we're just going to check that the expected widgets exist.
   assert {
-    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[0].properties.title == "All Fargate Tasks Configuration and Consumption Details (CPU and Memory)"
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[0].properties.title == "Deployed Application Images"
+    error_message = "Deployed Application Images widget is not created"
+  }
+
+  assert {
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[1].properties.title == "Deployed Sidecar Images"
+    error_message = "Deployed Sidecar Images"
+  }
+
+  assert {
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[2].properties.title == "All Fargate Tasks Configuration and Consumption Details (CPU and Memory)"
     error_message = "Configuration and Consumption Details (CPU and Memory) widget is not created"
   }
 
   assert {
-    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[1].properties.title == "Top 10 Fargate Tasks with Optimization Opportunities (CPU)"
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[3].properties.title == "Top 10 Fargate Tasks with Optimization Opportunities (CPU)"
     error_message = "Optimization Opportunities (CPU) widget is not created"
   }
 
   assert {
-    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[2].properties.title == "Top 10 Fargate Tasks with Optimization Opportunities (Memory)"
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[4].properties.title == "Top 10 Fargate Tasks with Optimization Opportunities (Memory)"
     error_message = "Optimization Opportunities (Memory) widget is not created"
   }
 
   assert {
-    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[3].properties.title == "CPU Reserved Vs Avg Usage (All Fargate Tasks)"
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[5].properties.title == "CPU Reserved Vs Avg Usage (All Fargate Tasks)"
     error_message = "CPU Reserved Vs Avg Usage widget is not created"
   }
 
   assert {
-    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[4].properties.title == "Memory Reserved Vs Avg Usage (All Fargate Tasks)"
+    condition     = jsondecode(aws_cloudwatch_dashboard.compute.dashboard_body).widgets[6].properties.title == "Memory Reserved Vs Avg Usage (All Fargate Tasks)"
     error_message = "Memory Reserved Vs Avg Usage widget is not created"
   }
 }


### PR DESCRIPTION
Add tables to environment CloudWatch dashboards to show deployed application and sidecar images

![image](https://github.com/user-attachments/assets/24ee6ba6-b974-4a82-a1a3-a8a0832b0bb8)
![image](https://github.com/user-attachments/assets/5d445d33-c191-4db3-8b7d-386d68db39e3)

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
