### PR TITLE
fix: DBTP-1991 Allow environment pipeline to adjust ElastiCache replication count

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -540,11 +540,13 @@ data "aws_iam_policy_document" "redis" {
 
   statement {
     actions = [
-      "elasticache:CreateReplicationGroup",
       "elasticache:AddTagsToResource",
+      "elasticache:CreateReplicationGroup",
+      "elasticache:DecreaseReplicaCount",
+      "elasticache:DeleteReplicationGroup",
       "elasticache:DescribeReplicationGroups",
+      "elasticache:IncreaseReplicaCount",
       "elasticache:ListTagsForResource",
-      "elasticache:DeleteReplicationGroup"
     ]
     resources = [
       "arn:aws:elasticache:${local.account_region}:replicationgroup:*",

--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -547,6 +547,7 @@ data "aws_iam_policy_document" "redis" {
       "elasticache:DescribeReplicationGroups",
       "elasticache:IncreaseReplicaCount",
       "elasticache:ListTagsForResource",
+      "elasticache:ModifyReplicationGroup",
     ]
     resources = [
       "arn:aws:elasticache:${local.account_region}:replicationgroup:*",


### PR DESCRIPTION
Addresses [DBTP-1791](https://uktrade.atlassian.net/browse/DBTP-1791).

Because the end to end tests failed.

---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] ~Includes tests (or an explanation for why it doesn't)~
- [ ] ~Includes any applicable changes to the documentation in this code base~
- [ ] ~Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing

[Regression test run](https://763451185160-2qjkzelg.eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/pull-request-end-to-end-tests/executions/65425bab-934b-4133-8876-349106e9a768/visualization?region=eu-west-2).

[DBTP-1791]: https://uktrade.atlassian.net/browse/DBTP-1791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ