### PR TITLE
fix: Redis plans being ignored

### DIFF
--- a/extensions/locals.tf
+++ b/extensions/locals.tf
@@ -1,8 +1,8 @@
 locals {
   plans = {
-    opensearch        = yamldecode(file("${path.module}/../opensearch/plans.yml"))
-    postgres          = yamldecode(file("${path.module}/../postgres/plans.yml"))
-    elasticache-redis = yamldecode(file("${path.module}/../elasticache-redis/plans.yml"))
+    opensearch = yamldecode(file("${path.module}/../opensearch/plans.yml"))
+    postgres   = yamldecode(file("${path.module}/../postgres/plans.yml"))
+    redis      = yamldecode(file("${path.module}/../elasticache-redis/plans.yml"))
   }
 
   # So we don't hit a Parameter Store limit, filter environment config for extensions so it only includes the defaults (`"*"`) and the current environment


### PR DESCRIPTION
The plan was being looked up with "elasticache-redis" but we specify the type as just "redis". This was causing the plan to not be found and terraform fall back to the defaults.

We specify the tiny plan in demodjango
```
demodjango-redis:
  type: redis
  environments:
    "*":
      engine: "7.1"
      plan: tiny
      apply_immediately: true
```
Which should be:
```
tiny:
  replicas: 0
  instance: cache.t4g.small
```

But terraform is trying to do:
<img width="645" alt="image" src="https://github.com/user-attachments/assets/832ee95b-8194-4764-af72-d2e62a23a4e2" />


---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
