### PR TITLE
DBTP-1700 Deprecate cross_enviroment_service_access application property

### DIFF
--- a/s3/tests/unit.tftest.hcl
+++ b/s3/tests/unit.tftest.hcl
@@ -521,7 +521,6 @@ run "aws_s3_bucket_cross_environment_service_access_read_write_unit_test" {
       "type"        = "s3",
       "cross_environment_service_access" = {
         "test-access" = {
-          "application"       = "app",
           "environment"       = "test",
           "account"           = "123456789012",
           "service"           = "service",
@@ -573,7 +572,6 @@ run "aws_s3_bucket_cross_environment_service_access_read_only_unit_test" {
       "type"        = "s3",
       "cross_environment_service_access" = {
         "test-access" = {
-          "application"       = "app",
           "environment"       = "test",
           "account"           = "123456789012",
           "service"           = "service",
@@ -609,7 +607,6 @@ run "aws_s3_bucket_cross_environment_service_access_write_only_unit_test" {
       "type"        = "s3",
       "cross_environment_service_access" = {
         "test-access" = {
-          "application"       = "app",
           "environment"       = "test",
           "account"           = "123456789012",
           "service"           = "service",
@@ -645,7 +642,6 @@ run "aws_s3_bucket_cross_environment_service_access_invalid_cyber_sign_off" {
       "type"        = "s3",
       "cross_environment_service_access" = {
         "test-access" = {
-          "application"       = "app",
           "environment"       = "test",
           "account"           = "123456789012",
           "service"           = "service",

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -43,7 +43,9 @@ variable "config" {
     })))
     # NOTE: allows access to S3 bucket from DBT Platform managed service roles, also generates Copilot addon for service access
     cross_environment_service_access = optional(map(object({
-      application       = string
+      # Deprecated: We didn't implement cross application access, no service teams are asking for it.
+      # application should be removed once we can confirm that no-one is using it.
+      application       = optional(string)
       account           = string
       environment       = string
       service           = string


### PR DESCRIPTION
Found while working on [DBTP-1700](https://uktrade.atlassian.net/browse/DBTP-1700)

Just made it optional for now and will document it as deprecated in https://github.com/uktrade/platform-documentation/pull/498.

---
## Checklist:

### Title:
- [ ] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] ~Includes any applicable changes to the documentation in this code base~
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
