### PR TITLE
fix: DBTP-1563 - Use iam_role_policy instead of deprecated inline policies

### DIFF
--- a/elasticache-redis/main.tf
+++ b/elasticache-redis/main.tf
@@ -89,11 +89,6 @@ resource "aws_iam_role" "conduit_ecs_task_role" {
   name               = "${var.name}-${var.application}-${var.environment}-conduitEcsTask"
   assume_role_policy = data.aws_iam_policy_document.assume_ecstask_role.json
 
-  inline_policy {
-    name   = "AllowReadingofCMKSecrets"
-    policy = data.aws_iam_policy_document.access_ssm_with_kms.json
-  }
-
   tags = local.tags
 }
 
@@ -108,6 +103,12 @@ data "aws_iam_policy_document" "assume_ecstask_role" {
 
     actions = ["sts:AssumeRole"]
   }
+}
+
+resource "aws_iam_role_policy" "kms_access_for_conduit_ecs_task" {
+  name   = "AllowReadingofCMKSecrets"
+  role   = aws_iam_role.conduit_ecs_task_role.name
+  policy = data.aws_iam_policy_document.access_ssm_with_kms.json
 }
 
 data "aws_iam_policy_document" "access_ssm_with_kms" {

--- a/elasticache-redis/tests/unit.tftest.hcl
+++ b/elasticache-redis/tests/unit.tftest.hcl
@@ -443,4 +443,14 @@ run "test_create_conduit_iam_role" {
     condition     = strcontains(jsonencode(data.aws_iam_policy_document.assume_ecstask_role.statement[0].principals), "ecs-tasks.amazonaws.com")
     error_message = "Should be: ecs-tasks.amazonaws.com"
   }
+
+  # Check kms access role policy
+  assert {
+    condition     = aws_iam_role_policy.kms_access_for_conduit_ecs_task.name == "AllowReadingofCMKSecrets"
+    error_message = "Should be: 'AllowReadingofCMKSecrets'"
+  }
+  assert {
+    condition     = aws_iam_role_policy.kms_access_for_conduit_ecs_task.role == "test-redis-test-application-test-environment-conduitEcsTask"
+    error_message = "Should be: 'test-redis-test-application-test-environment-conduitEcsTask'"
+  }
 }

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
         x : 0,
         type : "log",
         properties : {
-          query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields fromMillis(Timestamp) as Time, ClusterName as Cluster, TaskDefinitionFamily as Service, ContainerName as Container, Image\n| filter @message like 'application:'\n| sort Cluster, Service, Container\n| dedup Service, Container",
+          query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields fromMillis(Timestamp) as Time, ClusterName as Cluster, TaskDefinitionFamily as Service, ContainerName as Container, Image\n| filter @message like '${var.application}/'\n| sort Cluster, Service, Container\n| dedup Service, Container",
           region : "eu-west-2",
           stacked : false,
           title : "Deployed Application Images",
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_dashboard" "compute" {
         x : 0,
         type : "log",
         properties : {
-          query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields fromMillis(Timestamp) as Time, ClusterName as Cluster, TaskDefinitionFamily as Service, ContainerName as Container, Image\n| filter @message like '\"Image\":'\n| filter @message not like 'application:'\n| sort Cluster, Service, Container\n| dedup Service, Container",
+          query : "SOURCE '/aws/ecs/containerinsights/${var.application}-${var.environment}/performance' | fields fromMillis(Timestamp) as Time, ClusterName as Cluster, TaskDefinitionFamily as Service, ContainerName as Container, Image\n| filter @message like '\"Image\":'\n| filter @message not like '${var.application}/'\n| sort Cluster, Service, Container\n| dedup Service, Container",
           region : "eu-west-2",
           stacked : false,
           title : "Deployed Sidecar Images",

--- a/opensearch/main.tf
+++ b/opensearch/main.tf
@@ -229,11 +229,6 @@ resource "aws_iam_role" "conduit_ecs_task_role" {
   name               = "${var.name}-${var.application}-${var.environment}-conduitEcsTask"
   assume_role_policy = data.aws_iam_policy_document.assume_ecstask_role.json
 
-  inline_policy {
-    name   = "AllowReadingofCMKSecrets"
-    policy = data.aws_iam_policy_document.access_ssm_with_kms.json
-  }
-
   tags = local.tags
 }
 
@@ -248,6 +243,12 @@ data "aws_iam_policy_document" "assume_ecstask_role" {
 
     actions = ["sts:AssumeRole"]
   }
+}
+
+resource "aws_iam_role_policy" "kms_access_for_conduit_ecs_task" {
+  name   = "AllowReadingofCMKSecrets"
+  role   = aws_iam_role.conduit_ecs_task_role.name
+  policy = data.aws_iam_policy_document.access_ssm_with_kms.json
 }
 
 data "aws_iam_policy_document" "access_ssm_with_kms" {

--- a/opensearch/tests/unit.tftest.hcl
+++ b/opensearch/tests/unit.tftest.hcl
@@ -462,4 +462,14 @@ run "aws_kms_key_unit_test" {
     condition     = strcontains(jsonencode(data.aws_iam_policy_document.assume_ecstask_role.statement[0].principals), "ecs-tasks.amazonaws.com")
     error_message = "Should be: ecs-tasks.amazonaws.com"
   }
+
+  # Check kms access role policy
+  assert {
+    condition     = aws_iam_role_policy.kms_access_for_conduit_ecs_task.name == "AllowReadingofCMKSecrets"
+    error_message = "Should be: 'AllowReadingofCMKSecrets'"
+  }
+  assert {
+    condition     = aws_iam_role_policy.kms_access_for_conduit_ecs_task.role == "my_name-my_app-my_env-conduitEcsTask"
+    error_message = "Should be: 'my_name-my_app-my_env-conduitEcsTask'"
+  }
 }

--- a/postgres/lambda.tf
+++ b/postgres/lambda.tf
@@ -44,11 +44,12 @@ resource "aws_iam_role" "lambda-execution-role" {
   name               = "${local.name}-lambda-role"
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.lambda-assume-role-policy.json
+}
 
-  inline_policy {
-    name   = "${local.name}-execution-policy"
-    policy = data.aws_iam_policy_document.lambda-execution-policy.json
-  }
+resource "aws_iam_role_policy" "lambda-execution-role-policy" {
+  name   = "${local.name}-execution-policy"
+  role   = aws_iam_role.lambda-execution-role.name
+  policy = data.aws_iam_policy_document.lambda-execution-policy.json
 }
 
 data "aws_security_group" "rds-endpoint" {

--- a/postgres/tests/unit.tftest.hcl
+++ b/postgres/tests/unit.tftest.hcl
@@ -660,6 +660,20 @@ run "aws_iam_role_unit_test" {
     error_message = "Should be: {\"Sid\": \"AllowLambdaAssumeRole\"}"
   }
 
+  # Check lambda execution role policy
+  assert {
+    condition     = aws_iam_role_policy.lambda-execution-role-policy.name == "test-application-test-env-test-name-execution-policy"
+    error_message = "Should be: 'test-application-test-env-test-name-execution-policy'"
+  }
+  assert {
+    condition     = aws_iam_role_policy.lambda-execution-role-policy.role == "test-application-test-env-test-name-lambda-role"
+    error_message = "Should be: 'test-application-test-env-test-name-lambda-role'"
+  }
+  assert {
+    condition     = aws_iam_role_policy.lambda-execution-role-policy.policy == "{\"Sid\": \"LambdaExecutionPolicy\"}"
+    error_message = "Unexpected policy"
+  }
+
   # Check the contents of the policy document
   assert {
     condition     = contains(data.aws_iam_policy_document.lambda-assume-role-policy.statement[0].actions, "sts:AssumeRole")


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1563

Fix these warnings every time we run a terraform command:

```
│ Warning: Argument is deprecated
│ 
│   with module.extensions.module.elasticache-redis["demodjango-redis"].aws_iam_role.conduit_ecs_task_role,
│   on .terraform/modules/extensions/elasticache-redis/main.tf line 88, in resource "aws_iam_role" "conduit_ecs_task_role":
│   88: resource "aws_iam_role" "conduit_ecs_task_role" {
```


---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
