### PR TITLE
fix: Fix missing tag for SSM parameter EGRESS_IP

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -118,7 +118,13 @@ resource "aws_ssm_parameter" "combined_nat_gateway_eips" {
   name  = "/${var.arg_name}/EGRESS_IPS"
   type  = "String"
   value = join(",", local.nat_gateway_eips)
-  tags  = local.tags
+  tags = merge(
+    local.tags,
+    {
+      "copilot-application" = "__all__"
+    }
+  )
+
 }
 
 

--- a/vpc/tests/unit.tftest.hcl
+++ b/vpc/tests/unit.tftest.hcl
@@ -64,6 +64,12 @@ run "aws_vpc_unit_test" {
   }
 
   # aws_ssm_parameter.combined_nat_gateway_eips.value cannot be tested on a plan
+
+  assert {
+    condition     = lookup(aws_ssm_parameter.combined_nat_gateway_eips.tags, "copilot-application", "") == "__all__"
+    error_message = "Tag 'copilot-application' should be set to '__all__'"
+  }
+
 }
 
 run "aws_security_group_unit_test" {


### PR DESCRIPTION
Ad-hoc quick fix

The [demodjango-deploy/copilot/{service}/overrides/cfn.patches.yml](https://github.com/uktrade/demodjango-deploy/blob/fe0daac6e5d801c3bc6bcea7f2efc99c2f3bb0d5/copilot/web/overrides/cfn.patches.yml#L26) file grants the service access to the SSM params that have the tag:
```
copilot-application': '__all__'
```
We need to add that tag to the EGRESS_IP SSM param in order for the copilot/{service}/manifest.yml to use the SSM parameter.

Each time an environment gets re-provisoned it was wiping the manually added tag and this breaks the codebase pipeline as thew web service depends on the EGRESS_IP SSM param

[Deployment failure logs](https://eu-west-2.console.aws.amazon.com/ecs/v2/clusters/demodjango-tony/services/demodjango-tony-web-Service-DdRQaBu2AQnW/tasks/af7a086619ba4fa0a03404cc0faf803f/configuration?selectedContainer=appconfig)



---
## Checklist:

### Title:
- [x] Scope included as per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Ticket reference included (unless it's a quick out of ticket thing)
### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
### Tasks:
- [x] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
