### PR TITLE
fix: Create codebase parameter with codebase config (DBTP-1892)

### DIFF
--- a/codebase-pipelines/ssm.tf
+++ b/codebase-pipelines/ssm.tf
@@ -1,0 +1,17 @@
+resource "aws_ssm_parameter" "codebase_config" {
+  name        = "/copilot/applications/${var.application}/codebases/${var.codebase}"
+  description = "Configuration for the ${var.codebase} codebase, used by platform-helper commands"
+  type        = "String"
+  value = jsonencode({
+    "name" : var.codebase,
+    "repository" : var.repository,
+    "deploy_repository_branch" : var.deploy_repository_branch,
+    "additional_ecr_repository" : var.additional_ecr_repository,
+    "slack_channel" : var.slack_channel,
+    "requires_image_build" : var.requires_image_build,
+    "services" : var.services,
+    "pipelines" : var.pipelines
+  })
+
+  tags = local.tags
+}


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1892

Missing parameter causing platform-helper codebase list to fail

Before
![image](https://github.com/user-attachments/assets/1c888625-7627-4f7e-ab1f-152e7192ad0c)

After
![image](https://github.com/user-attachments/assets/d4856244-9ab1-4df7-93dd-29756956da02)



---
## Checklist:

### Title:
- [ ] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
