### PR TITLE
fix: Add missing action to environment pipelines (DBTP-1972)

### DIFF
--- a/environment-pipelines/iam.tf
+++ b/environment-pipelines/iam.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "access_artifact_store" {
 
   statement {
     effect    = "Allow"
-    actions   = ["codestar-connections:UseConnection"]
+    actions   = ["codestar-connections:UseConnection", "codeconnections:ListTagsForResource"]
     resources = [data.aws_codestarconnections_connection.github_codestar_connection.arn]
   }
 


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1972 - an issue that was raised in platform-requests.

There is a missing permission in the codeconnection resource within `environment-pipelines` that prevented one of the service's environment pipeline from running successfully after they had deployed the data copy pipeline to their account. This ticket simply adds that permission in

We have manually tested this through adding the permission via the IAM policy console and noted a successful pipeline execution


---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)

### Tasks:
- [ ] [Trigger the pull request regression tests for this branch](https://github.com/uktrade/platform-tools?tab=readme-ov-file#regression-tests) and confirm that they are passing
